### PR TITLE
Fix regional report to properly calculate game averages

### DIFF
--- a/src/app/Http/Controllers/CenterStatsController.php
+++ b/src/app/Http/Controllers/CenterStatsController.php
@@ -141,7 +141,7 @@ class CenterStatsController extends Controller
             foreach ($week as $type => $data) {
                 // GITW is calculated as an average, so we need the total first
                 $total      = $data->gitw;
-                $data->gitw = round($total / $count);
+                $data->gitw = ($total / $count);
 
                 $globalReportData[] = $data;
             }

--- a/src/app/Reports/Arrangements/GamesByWeek.php
+++ b/src/app/Reports/Arrangements/GamesByWeek.php
@@ -27,7 +27,8 @@ class GamesByWeek extends BaseArrangement
 
             $totalPoints = null;
             foreach (['cap', 'cpc', 't1x', 't2x', 'gitw', 'lf'] as $game) {
-                $reportData[$dateString][$type][$game] = $data->$game;
+                // Round game because some reports calculate average game scores and values are provided as floats
+                $reportData[$dateString][$type][$game] = round($data->$game);
 
                 if ($complement) {
                     if ($type == 'promise') {
@@ -38,7 +39,7 @@ class GamesByWeek extends BaseArrangement
 
                     $points = Scoreboard::getPoints($percent, $game);
 
-                    $reportData[$dateString]['percent'][$game] = $percent;
+                    $reportData[$dateString]['percent'][$game] = round($percent);
                     $reportData[$dateString]['points'][$game] = $points;
                     $totalPoints += $points;
                 }

--- a/src/tests/unit/ScoreboardTest.php
+++ b/src/tests/unit/ScoreboardTest.php
@@ -134,11 +134,11 @@ class ScoreboardTest extends TestAbstract
                 87,
                 87,
             ],
-            // over 100% returns 100%
+            // over 100% returns over 100%
             [
                 100,
                 110,
-                100,
+                110,
             ],
             // less than 0% returns 0%
             [
@@ -152,23 +152,23 @@ class ScoreboardTest extends TestAbstract
                 3,
                 75,
             ],
-            // rounds up (66.66 => 67)
+            // returns float
             [
                 3,
                 2,
-                67,
+                (float) ((2/3) * 100),
             ],
-            // rounds down (33.33 => 33)
+            // returns float
             [
                 3,
                 1,
-                33,
+                (float) ((1/3) * 100),
             ],
-            // rounds up (12.5 => 13)
+            // returns float
             [
                 8,
                 1,
-                13,
+                12.500,
             ],
             // Promise 0 always 0
             [
@@ -479,6 +479,30 @@ class ScoreboardTest extends TestAbstract
                 75,
                 'CAP',
                 2,
+            ],
+            // Float percent rounds down correctly (74.33333 => 74)
+            [
+                (float) ((1/3) + 74),
+                'cap',
+                0,
+            ],
+            // Float percent rounds up correctly (79.66666 => 80)
+            [
+                (float) ((2/3) + 79),
+                'cap',
+                4,
+            ],
+            // Float percent rounds up correctly (89.5000 => 90)
+            [
+                (float) ((1/2) + 89),
+                'cap',
+                6,
+            ],
+            // Over 100% returns max points
+            [
+                110,
+                'cap',
+                8,
             ],
         ];
     }


### PR DESCRIPTION
Regional reports calculate the an average for the GITW game, which must remain a float until we calculate the points or we may introduce rounding errors.
Fixed by returning floats from Scoreboard::calculePercent(), and handling the rounding at display time.