### PR TITLE
Don't enforce the sheet version when generating the results report

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -678,7 +678,7 @@ class StatsReportController extends ReportDispatchAbstractController
 
         if ($sheetPath) {
             try {
-                $importer = new XlsxImporter($sheetPath, basename($sheetPath), $statsReport->reportingDate, true);
+                $importer = new XlsxImporter($sheetPath, basename($sheetPath), $statsReport->reportingDate, false);
                 $importer->import(false);
                 $sheet = $importer->getResults();
             } catch (Exception $e) {


### PR DESCRIPTION
No need because it would be caught on import and we don't want to show the report as having an error later in the quarter.