### PR TITLE
Persistent live scoreboard. Closes #351.

### DIFF
--- a/src/app/Api/Base/AuthenticatedApiBase.php
+++ b/src/app/Api/Base/AuthenticatedApiBase.php
@@ -2,16 +2,17 @@
 namespace TmlpStats\Api\Base;
 
 use Gate;
-use TmlpStats\User;
+use TmlpStats\Api;
 
 class AuthenticatedApiBase
 {
     protected $user = null;
     protected $gate = null;
 
-    public function __construct(User $user)
+    public function __construct(Api\Context $context)
     {
-        $this->user = $user;
-        $this->gate = Gate::forUser($user);
+        $this->context = $context;
+        $this->user = $context->getUser();
+        $this->gate = Gate::forUser($this->user);
     }
 }

--- a/src/app/Api/Context.php
+++ b/src/app/Api/Context.php
@@ -1,35 +1,45 @@
 <?php namespace TmlpStats\Api;
 
 use App;
-use Illuminate\Auth\Guard;
-use Illuminate\Session\SessionManager;
-use TmlpStats\Http\Controllers\Controller;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Http\Request;
 use TmlpStats as Models;
+use TmlpStats\Http\Controllers\Controller;
 
-class Context {
+/**
+ * Context is decisive.
+ */
+class Context
+{
     protected $user = null;
-    protected $session = null;
     protected $request = null;
 
-    public function __construct(Guard $auth, SessionManager $session, Request $request) {
+    public function __construct(Guard $auth, Request $request)
+    {
         $this->user = $auth->user();
-        $this->session = $session;
         $this->request = $request;
     }
 
-    public function getCenter() {
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    public function getCenter()
+    {
         // TODO do this right, don't make it reliant on controller state, invert the paradigm.
         return App::make(Controller::class)->getCenter($this->request);
     }
 
-    public function getRegion() {
+    public function getRegion()
+    {
         // TODO do this right, don't make it reliant on controller state, invert the paradigm.
         return App::make(Controller::class)->getRegion($this->request);
     }
 
-    public function getRawSetting($name, $center=null) {
-        if ($center == null){
+    public function getRawSetting($name, $center = null)
+    {
+        if ($center == null) {
             $center = $this->getCenter();
         }
         $setting = Models\Setting::get($name, $center);
@@ -38,7 +48,8 @@ class Context {
         }
     }
 
-    public function getSetting($name, $center=null) {
+    public function getSetting($name, $center = null)
+    {
         $value = $this->getRawSetting($name, $center);
         if ($value === 'false') {
             return false;

--- a/src/app/Domain/Scoreboard.php
+++ b/src/app/Domain/Scoreboard.php
@@ -1,0 +1,149 @@
+<?php
+namespace TmlpStats\Domain;
+
+use Illuminate\Contracts\Support\Arrayable;
+use TmlpStats as Models;
+
+/**
+ * Represents a six-game scoreboard (cap, cpc, t1x etc.)
+ *
+ * This is a mutable structure which can marshal to/from arrays.
+ * It will also do some bonus things.
+ */
+class Scoreboard implements Arrayable
+{
+    protected $games = [];
+
+    protected function __construct()
+    {
+        foreach (Models\Scoreboard::GAME_KEYS as $gameKey) {
+            $this->games[$gameKey] = new ScoreboardGame($gameKey);
+        }
+    }
+
+    /** Create a scoreboard that's blank */
+    public static function blank()
+    {
+        return new static();
+    }
+
+    /**
+     * Create a scoreboard view from the typical array format
+     * @return Scoreboard
+     */
+    public static function fromArray($data)
+    {
+        $scoreboard = static::blank();
+        $scoreboard->parseArray($data);
+        return $scoreboard;
+    }
+
+    ////////////
+    /// Calculation / business logic
+
+    /**
+     * Calculate points for this entire row
+     * @return int Points total; 0-24
+     */
+    public function points()
+    {
+        $total = 0;
+        foreach ($this->games as &$game) {
+            $total += $game->points();
+        }
+        return $total;
+    }
+
+    /**
+     * Rating for this row.
+     * @return string Rating, e.g. "Ineffective", "Effective"
+     */
+    public function rating()
+    {
+        return Models\Scoreboard::getRating($this->points());
+    }
+
+    public function game($gameKey)
+    {
+        return $this->games[$gameKey];
+    }
+
+    ////////////
+    /// Helpers for client code (quick set/get, etc)
+
+    /**
+     * A neat little helper to loop through all the games.
+     * @param  \Closure $callback A function callback which will get an instance of the game
+     */
+    public function eachGame(\Closure $callback)
+    {
+        foreach ($this->games as &$game) {
+            //$bound = $callback->bindTo($game);
+            $callback($game);
+        }
+    }
+
+    /**
+     * setValue is a shortcut for setting a value on a single key
+     * @param string $gameKey The key of the game 'cap', 'cpc', etc
+     * @param string $type    The type of value we're updating; 'promise', 'actual'
+     * @param int    $value   The value we're setting this to.
+     */
+    public function setValue($gameKey, $type, $value)
+    {
+        $game = &$this->games[$gameKey];
+        $game->set($type, $value);
+    }
+
+    ////////////
+    /// Working with the commonly used array format
+
+    public function parseArray($data)
+    {
+        foreach ($this->games as $gameKey => &$game) {
+            if (($promise = array_get($data, "promise.{$gameKey}", null)) !== null) {
+                $game->setPromise($promise);
+            }
+            if (($actual = array_get($data, "actual.{$gameKey}", null)) !== null) {
+                $game->setActual($actual);
+            }
+        }
+    }
+
+    /**
+     * Return as the "standard" array format
+     * @return array
+     */
+    public function toBasicArray()
+    {
+        $v = $this->toArray();
+        unset($v['games']);
+        return $v;
+    }
+
+    public function toArray()
+    {
+        $v = [
+            'promise' => [],
+            'actual' => [],
+            'percent' => [],
+            'points' => [
+                'total' => $this->points(),
+            ],
+            'rating' => $this->rating(),
+            'games' => [],
+        ];
+
+        foreach ($this->games as $gameKey => &$game) {
+            $g = [];
+            $v['promise'][$gameKey] = $g['promise'] = $game->promise();
+            $v['actual'][$gameKey] = $g['actual'] = $game->actual();
+            $v['percent'][$gameKey] = $g['percent'] = $game->percent();
+            $v['points'][$gameKey] = $g['points'] = $game->points();
+            // set the additional key for great format switch
+            $v['games'][$gameKey] = $g;
+        }
+        return $v;
+    }
+
+}

--- a/src/app/Domain/ScoreboardGame.php
+++ b/src/app/Domain/ScoreboardGame.php
@@ -1,0 +1,79 @@
+<?php
+namespace TmlpStats\Domain;
+
+use TmlpStats as Models;
+
+/**
+ * Represents one game (cap/cpc/etc) storing both promise and actual values.
+ *
+ * Contains the necessary logic by which to determine points and percentage.
+ */
+class ScoreboardGame
+{
+    public $key;
+    private $promise = 0;
+    private $actual = 0;
+
+    public function __construct($gameKey)
+    {
+        $this->key = $gameKey;
+    }
+
+    public function promise()
+    {
+        return $this->promise;
+    }
+
+    public function actual()
+    {
+        return $this->actual;
+    }
+
+    public function percent()
+    {
+        return round(static::calculatePercent($this->promise, $this->actual));
+    }
+
+    public function points()
+    {
+        // yes I know, this recalculates a lot of things. A little math never hurt anybody.
+        return static::getPoints($this->key, $this->percent());
+    }
+
+    public function setPromise($promise)
+    {
+        $this->promise = $promise;
+    }
+
+    public function setActual($actual)
+    {
+        $this->actual = $actual;
+    }
+
+    public function set($type, $value)
+    {
+        if ($type == 'promise') {
+            $this->setPromise($value);
+        } else if ($type == 'actual') {
+            $this->setActual($value);
+        } else {
+            throw new \Exception("Unknown type {$type}");
+        }
+    }
+
+    ////////////////////////////////////////////////////////
+    /// STATIC FUNCTIONS TO DESCRIBE REUSABLE BUSINESS RULES
+
+    public static function calculatePercent($promise, $actual)
+    {
+        return Models\Scoreboard::calculatePercent($promise, $actual);
+
+    }
+
+    public static function getPoints($gameKey, $percent)
+    {
+        // note the intentional inversion of these two values from the one on Scoreboard
+        return Models\Scoreboard::getPoints($percent, $gameKey);
+    }
+
+}

--- a/src/app/Domain/ScoreboardMultiWeek.php
+++ b/src/app/Domain/ScoreboardMultiWeek.php
@@ -1,0 +1,39 @@
+<?php
+namespace TmlpStats\Domain;
+
+use Carbon\Carbon;
+
+/**
+ * A little bonus
+ *
+ * A container for a scoreboard consisting of multiple weeks.
+ * This can add any number of features in the future.
+ */
+class ScoreboardMultiWeek
+{
+    protected $weeks = [];
+
+    public function ensureWeek(Carbon $day)
+    {
+        $key = $day->toDateString();
+        if (!array_key_exists($key, $this->weeks)) {
+            $this->weeks[$key] = Scoreboard::blank();
+        }
+        return $this->weeks[$key];
+    }
+
+    /**
+     * Return all in the "canonical format"
+     * @return [type] [description]
+     */
+    public function toArray()
+    {
+        $output = [];
+        $weeks = $this->weeks;
+        ksort($weeks);
+        foreach ($weeks as $key => &$scoreboard) {
+            $output[$key] = $scoreboard->toArray();
+        }
+        return $output;
+    }
+}

--- a/src/app/Http/Controllers/CenterController.php
+++ b/src/app/Http/Controllers/CenterController.php
@@ -143,14 +143,12 @@ class CenterController extends Controller
         }
 
         $liveScoreboard = true;
-        $editableLiveScoreboard = false;
 
         $data = compact(
             'center',
             'statsReport',
             'reportUrl',
-            'liveScoreboard',
-            'editableLiveScoreboard'
+            'liveScoreboard'
         );
 
         return view('centers.dashboard')->with(array_merge($data, $weekData));

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -431,7 +431,6 @@ class StatsReportController extends ReportDispatchAbstractController
         return $response;
     }
 
-
     public function getCoursesSummary(StatsReport $statsReport)
     {
         $courses = App::make(CoursesController::class)->getByStatsReport($statsReport);
@@ -513,17 +512,17 @@ class StatsReportController extends ReportDispatchAbstractController
         $applicationWithdraws = [];
         if ($registrations) {
             // Application Status
-            $a            = new Arrangements\TmlpRegistrationsByStatus([
+            $a = new Arrangements\TmlpRegistrationsByStatus([
                 'registrationsData' => $registrations,
-                'quarter'           => $statsReport->quarter,
+                'quarter' => $statsReport->quarter,
             ]);
             $applications = $a->compose();
             $applications = $applications['reportData'];
 
             // Application Withdraws
-            $a                    = new Arrangements\TmlpRegistrationsByIncomingQuarter([
+            $a = new Arrangements\TmlpRegistrationsByIncomingQuarter([
                 'registrationsData' => $registrations,
-                'quarter'           => $statsReport->quarter,
+                'quarter' => $statsReport->quarter,
             ]);
             $applicationWithdraws = $a->compose();
             $applicationWithdraws = $applicationWithdraws['reportData']['withdrawn'];
@@ -604,7 +603,6 @@ class StatsReportController extends ReportDispatchAbstractController
         $data = $this->getSummaryPageData($statsReport, true);
         $data['skip_navbar'] = true;
         $data['liveScoreboard'] = true;
-        $data['editableLiveScoreboard'] = false;
         return view('statsreports.details.mobile_summary', $data);
     }
 

--- a/src/app/Reports/Arrangements/GamesByWeek.php
+++ b/src/app/Reports/Arrangements/GamesByWeek.php
@@ -1,5 +1,6 @@
 <?php namespace TmlpStats\Reports\Arrangements;
 
+use TmlpStats\Domain\ScoreboardMultiWeek;
 use TmlpStats\Scoreboard;
 
 class GamesByWeek extends BaseArrangement
@@ -9,72 +10,37 @@ class GamesByWeek extends BaseArrangement
     /*
      * Builds an array of weekly promise/actual pairs
      * broken down by week
+     * @return
+     *     "2015-05-02" =>
+     *         promise =>
+     *             cap => 4
+     *             cpc => 10,
+     *             ...
+     *         actual => (same format as promise)
+     *         points => (same format as promise, plus "total" key)
+     *         rating => "Ineffective"
      */
     public function build($centerStatsData)
     {
-        $reportData = [];
+        $weeks = new ScoreboardMultiWeek();
+
         foreach ($centerStatsData as $data) {
 
             if (!$data) {
                 continue;
             }
-            $type = $data->type;
-            $dateString = $data->reportingDate->toDateString();
-            $reportData[$dateString][$type] = [];
 
-            $complement = isset($reportData[$dateString][$this->getComplementType($type)])
-                ? $reportData[$dateString][$this->getComplementType($type)]
-                : null;
+            $scoreboard = $weeks->ensureWeek($data->reportingDate);
 
-            $totalPoints = null;
             foreach (static::$scored_games as $game) {
                 // Round game because some reports calculate average game scores and values are provided as floats
-                $reportData[$dateString][$type][$game] = round($data->$game);
-
-                if ($complement) {
-                    if ($type == 'promise') {
-                        $percent = Scoreboard::calculatePercent($data->$game, $complement[$game]);
-                    } else {
-                        $percent = Scoreboard::calculatePercent($complement[$game], $data->$game);
-                    }
-
-                    $points = Scoreboard::getPoints($percent, $game);
-
-                    $reportData[$dateString]['percent'][$game] = round($percent);
-                    $reportData[$dateString]['points'][$game] = $points;
-                    $totalPoints += $points;
-                }
+                $scoreboard->setValue($game, $data->type, round($data->$game));
             }
-            if ($totalPoints !== null) {
-                $reportData[$dateString]['points']['total'] = $totalPoints;
-                $reportData[$dateString]['rating'] = Scoreboard::getRating($totalPoints);
-            }
+
         }
+
+        $reportData = $weeks->toArray();
 
         return compact('reportData');
-    }
-
-    public static function blankLayout()
-    {
-        $v = [
-            'promise' => [],
-            'actual' => [],
-            'percent' => [],
-            'points' => ['total' => 0],
-            'rating' => 'Ineffective',
-        ];
-        foreach (static::$scored_games as $game) {
-            foreach (['promise', 'actual', 'percent', 'points'] as $key) {
-                $v[$key][$game] = 0;
-            }
-        }
-        return $v;
-    }
-
-    protected function getComplementType($type)
-    {
-        return ($type === 'promise')
-            ? 'actual'
-            : 'promise';
     }
 }

--- a/src/app/TempScoreboard.php
+++ b/src/app/TempScoreboard.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TmlpStats;
+
+use Eloquence\Database\Traits\CamelCaseModel;
+use Illuminate\Database\Eloquent\Model;
+
+class TempScoreboard extends Model
+{
+    use CamelCaseModel;
+
+    protected $table = 'temp_scoreboard';
+    protected $dates = [
+        'expires_at',
+    ];
+    protected $guarded = ['created_at'];
+
+    /**
+     * Returns all the records from a center that are valid (not expired)
+     * @param  int $centerId  Center ID
+     * @param  Carbon $threshold  Threshold date
+     * @return array  Key=>scoreboard entry
+     */
+    public static function allValidFromCenter($centerId, $threshold = null)
+    {
+        $entries = static::whereCenterId($centerId)
+            ->where('updated_at', '>', $threshold)->get();
+
+        return static::entriesByRoutingKey($entries);
+    }
+
+    protected static function entriesByRoutingKey($entries)
+    {
+        $result = [];
+        foreach ($entries as $entry) {
+            $result[$entry->routingKey] = $entry;
+        }
+        return $result;
+    }
+}

--- a/src/app/TempScoreboardLog.php
+++ b/src/app/TempScoreboardLog.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TmlpStats;
+
+use Eloquence\Database\Traits\CamelCaseModel;
+use Illuminate\Database\Eloquent\Model;
+
+class TempScoreboardLog extends Model
+{
+    use CamelCaseModel;
+
+    protected $table = 'temp_scoreboard_log';
+    protected $guarded = ['id'];
+}

--- a/src/database/migrations/2016_03_24_003938_create_temp_scoreboard_table.php
+++ b/src/database/migrations/2016_03_24_003938_create_temp_scoreboard_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateTempScoreboardTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('temp_scoreboard', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('center_id')->unsigned();
+            $table->string('routing_key', 150);
+            $table->timestamps();
+            $table->dateTime('expires_at')->nullable();
+            $table->integer('value');
+            $table->unique(['center_id', 'routing_key']);
+        });
+
+        Schema::create('temp_scoreboard_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('center_id')->unsigned();
+            $table->integer('quarter_id')->unsigned()->nullable();
+            $table->integer('stats_report_id')->unsigned()->nullable();
+            $table->string('game', 50)->nullable();
+            $table->string('type', 50)->nullable();
+            $table->integer('value');
+            $table->timestamps();
+            $table->index(['center_id', 'quarter_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('temp_scoreboard_log');
+        Schema::dropIfExists('temp_scoreboard');
+    }
+}

--- a/src/tests/unit/Domain/ScoreboardTest.php
+++ b/src/tests/unit/Domain/ScoreboardTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace TmlpStats\Tests\Domain;
+
+use TmlpStats\Domain\Scoreboard;
+use TmlpStats\Tests\TestAbstract;
+
+class ScoreboardTest extends TestAbstract
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function testBasic()
+    {
+        $scoreboard = Scoreboard::blank();
+        $scoreboard->eachGame(function (&$game) {
+            $game->setPromise(100);
+            $game->setActual(92);
+        });
+        $this->assertEquals(21, $scoreboard->points());
+        $this->assertEquals('Effective', $scoreboard->rating());
+        $scoreboard->setValue('cap', 'actual', 88);
+        $this->assertEquals(19, $scoreboard->points());
+        $this->assertTrue(true);
+    }
+
+    public function testFromArray()
+    {
+        $v = [
+            'promise' => [
+                "cap" => 46, "cpc" => 19, "t1x" => 8, "t2x" => 2, "gitw" => 85, "lf" => 56,
+            ],
+            'actual' => [
+                "cap" => 48, "cpc" => 23, "t1x" => 8, "t2x" => 0, "gitw" => 75, "lf" => 53,
+            ],
+        ];
+        $scoreboard = Scoreboard::fromArray($v);
+        $this->assertEquals(8, $scoreboard->game('cap')->points());
+        $this->assertEquals(104, $scoreboard->game('cap')->percent());
+
+        $this->assertEquals(4, $scoreboard->game('cpc')->points());
+        $this->assertEquals(121, $scoreboard->game('cpc')->percent());
+
+        $this->assertEquals(3, $scoreboard->game('lf')->points());
+        $this->assertEquals(95, $scoreboard->game('lf')->percent());
+
+        $this->assertEquals('Effective', $scoreboard->rating());
+        $this->assertEquals(21, $scoreboard->points());
+    }
+}


### PR DESCRIPTION
* Add ORM model and migration for temp scoreboard
* Refactor some boilerplatey stuff for working with scoreboards, make
  it type safe and easier to deal with.