### PR TITLE
Use context for figuring out region and oftentimes center

### DIFF
--- a/src/app/Api/Context.php
+++ b/src/app/Api/Context.php
@@ -13,6 +13,8 @@ class Context
 {
     protected $user = null;
     protected $request = null;
+    protected $region = null;
+    protected $center = null;
 
     public function __construct(Guard $auth, Request $request)
     {
@@ -25,16 +27,45 @@ class Context
         return $this->user;
     }
 
-    public function getCenter()
+    public function getCenter($fallback = false)
     {
-        // TODO do this right, don't make it reliant on controller state, invert the paradigm.
-        return App::make(Controller::class)->getCenter($this->request);
+        $center = $this->center;
+        if ($center == null && $fallback) {
+            // TODO do this right, don't make it reliant on controller state, invert the paradigm.
+            return App::make(Controller::class)->getCenter($this->request);
+        }
+        return $center;
     }
 
-    public function getRegion()
+    public function setCenter(Models\Center $center, $setRegion = true)
     {
-        // TODO do this right, don't make it reliant on controller state, invert the paradigm.
-        return App::make(Controller::class)->getRegion($this->request);
+        $this->center = $center;
+        if ($setRegion) {
+            $this->setRegion($center->region);
+        }
+    }
+
+    public function getGlobalRegion($fallback = false)
+    {
+        if ($region = $this->getRegion($fallback)) {
+            $region = $region->getParentGlobalRegion();
+        }
+        return $region;
+    }
+
+    public function getRegion($fallback = false)
+    {
+        $region = $this->region;
+        if ($region == null && $fallback) {
+            // TODO do this right, don't make it reliant on controller state, invert the paradigm.
+            $region = App::make(Controller::class)->getRegion($this->request);
+        }
+        return $region;
+    }
+
+    public function setRegion(Models\Region $region)
+    {
+        $this->region = $region;
     }
 
     public function getRawSetting($name, $center = null)
@@ -57,5 +88,11 @@ class Context
             return true;
         }
         return $value;
+    }
+
+    /** Currently unused. */
+    public function setReportingDate($reportingDate)
+    {
+        // TODO
     }
 }

--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -161,4 +161,15 @@ class Center extends Model
     {
         return $this->belongsTo('TmlpStats\Region');
     }
+
+    public function getUriCenterReport($reportingDate = null)
+    {
+        if ($reportingDate instanceof Carbon) {
+            $reportingDate = $reportingDate->toDateString();
+        }
+        return action('ReportsController@getCenterReport', [
+            'abbr' => strtolower($this->abbreviation),
+            'date' => $reportingDate,
+        ]);
+    }
 }

--- a/src/app/Http/Controllers/CenterController.php
+++ b/src/app/Http/Controllers/CenterController.php
@@ -6,6 +6,7 @@ use App;
 use Illuminate\Http\Request;
 use TmlpStats\Center;
 use TmlpStats\Http\Requests;
+use TmlpStats\Api;
 use TmlpStats\StatsReport;
 
 class CenterController extends Controller
@@ -115,7 +116,8 @@ class CenterController extends Controller
         if (!$center) {
             abort(404);
         }
-
+        $context = App::make(Api\Context::class);
+        $context->setCenter($center);
         $this->setCenter($center);
 
         $statsReport = StatsReport::byCenter($center)

--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -19,6 +19,7 @@ class Controller extends BaseController
 
     protected $region = null;
     protected $center = null;
+    protected $reportingDate = null;
 
     /**
      * Create a new controller instance.
@@ -105,7 +106,6 @@ class Controller extends BaseController
         // First try to get the date from the request
         if ($request->has('reportingDate') && preg_match('/^\d\d\d\d-\d\d-\d\d$/', $request->get('reportingDate'))) {
             $reportingDateString = $request->get('reportingDate');
-            Session::set('viewReportingDate', $reportingDateString);
         }
 
         // Then try to pull it from the session if it's there
@@ -127,11 +127,13 @@ class Controller extends BaseController
         }
 
         // Finally, if we don't have it yet make an educated guess
-        if ($reportingDateString && in_array($reportingDateString, $reportingDates)) {
-            $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString);
-        } else if (!$reportingDateString && $reportingDates) {
-            $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDates[0]);
-        } else if ($reportingDateString && !$reportingDates) {
+        if ($reportingDates) {
+            if (in_array($reportingDateString, $reportingDates)) {
+                $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString);
+            } else {
+                $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDates[0]);
+            }
+        } else if ($reportingDateString) {
             $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString);
         } else {
             $reportingDate = ImportManager::getExpectedReportDate();
@@ -165,7 +167,7 @@ class Controller extends BaseController
     public function setReportingDate(Carbon $reportingDate)
     {
         if ($reportingDate) {
-            Session::set('viewReportingDateId', $reportingDate->toDateString());
+            Session::set('viewReportingDate', $reportingDate->toDateString());
         }
 
         $this->reportingDate = $reportingDate;

--- a/src/app/Http/Controllers/ImportController.php
+++ b/src/app/Http/Controllers/ImportController.php
@@ -1,9 +1,11 @@
 <?php
 namespace TmlpStats\Http\Controllers;
 
+use App;
+use Auth;
 use Illuminate\Http\Request;
+use TmlpStats\Api;
 use TmlpStats\Import\ImportManager;
-
 use TmlpStats\StatsReport;
 
 class ImportController extends Controller
@@ -17,6 +19,7 @@ class ImportController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('role:statistician');
+        $this->context = App::make(Api\Context::class);
     }
 
     /**
@@ -24,15 +27,16 @@ class ImportController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function indexValidateSheet()
+    public function indexValidateSheet(Request $request)
     {
+        $this->context->setRegion(Auth::user()->homeRegion());
         $this->authorize('validate', StatsReport::class);
 
         return view('import.index')->with([
-            'submitReport'            => false, // Controls whether or not to show Submit button
-            'showUploadForm'          => true,
+            'submitReport' => false, // Controls whether or not to show Submit button
+            'showUploadForm' => true,
             'showReportCheckSettings' => true,
-            'expectedDate'            => ImportManager::getExpectedReportDate()->toDateString(),
+            'expectedDate' => ImportManager::getExpectedReportDate()->toDateString(),
         ]);
     }
 
@@ -44,6 +48,7 @@ class ImportController extends Controller
      */
     public function validateSheet(Request $request)
     {
+        $this->context->setRegion(Auth::user()->homeRegion());
         $this->authorize('validate', StatsReport::class);
 
         $enforceVersion = ($request->get('ignoreVersion') != 1);
@@ -63,11 +68,11 @@ class ImportController extends Controller
         $request->flashOnly('expectedReportDate', 'ignoreReportDate', 'ignoreVersion');
 
         return view('import.index')->with([
-            'submitReport'            => true,
-            'showUploadForm'          => true,
+            'submitReport' => true,
+            'showUploadForm' => true,
             'showReportCheckSettings' => true,
-            'expectedDate'            => ImportManager::getExpectedReportDate()->toDateString(),
-            'results'                 => $results,
+            'expectedDate' => ImportManager::getExpectedReportDate()->toDateString(),
+            'results' => $results,
         ]);
     }
 
@@ -81,8 +86,8 @@ class ImportController extends Controller
         $this->authorize('import', StatsReport::class);
 
         return view('admin.import')->with([
-            'submitReport'            => false, // Controls whether or not to show Submit button
-            'showUploadForm'          => true,
+            'submitReport' => false, // Controls whether or not to show Submit button
+            'showUploadForm' => true,
             'showReportCheckSettings' => false,
         ]);
     }
@@ -108,11 +113,11 @@ class ImportController extends Controller
         $request->flashOnly('expectedReportDate', 'ignoreReportDate', 'ignoreVersion');
 
         return view('admin.import')->with([
-            'submitReport'            => false, // Controls whether or not to show Submit button
-            'showUploadForm'          => true,
+            'submitReport' => false, // Controls whether or not to show Submit button
+            'showUploadForm' => true,
             'showReportCheckSettings' => false,
-            'expectedDate'            => ImportManager::getExpectedReportDate()->toDateString(),
-            'results'                 => $results,
+            'expectedDate' => ImportManager::getExpectedReportDate()->toDateString(),
+            'results' => $results,
         ]);
     }
 

--- a/src/app/Http/Controllers/ReportDispatchAbstractController.php
+++ b/src/app/Http/Controllers/ReportDispatchAbstractController.php
@@ -37,7 +37,7 @@ abstract class ReportDispatchAbstractController extends Controller
      * @param $report
      * @return \Illuminate\View\View
      */
-    abstract public function runDispatcher(Request $request, $model, $report);
+    abstract public function runDispatcher(Request $request, $model, $report, $extra);
 
     /**
      * Get the cache key to use for given model/report combo
@@ -77,7 +77,7 @@ abstract class ReportDispatchAbstractController extends Controller
      * @param $report
      * @return View|string|null
      */
-    public function dispatchReport(Request $request, $id, $report)
+    public function dispatchReport(Request $request, $id, $report, $extra = null)
     {
         $model = $this->getById($id);
 
@@ -102,7 +102,7 @@ abstract class ReportDispatchAbstractController extends Controller
             // Note: Make sure you don't write to the session during runDispatcher.
             session_write_close();
 
-            $response = $this->runDispatcher($request, $model, $report);
+            $response = $this->runDispatcher($request, $model, $report, $extra);
         }
 
         if ($this->useCache($report) && $response) {

--- a/src/app/Http/Controllers/ReportsController.php
+++ b/src/app/Http/Controllers/ReportsController.php
@@ -4,8 +4,8 @@ namespace TmlpStats\Http\Controllers;
 
 use App;
 use Carbon\Carbon;
-use Log;
 use Illuminate\Http\Request;
+use Log;
 use Session;
 use TmlpStats\Center;
 use TmlpStats\GlobalReport;
@@ -235,8 +235,8 @@ class ReportsController extends Controller
 
         if (!Session::has('viewCenterId')) {
             $center = $abbr
-                ? Center::abbreviation($abbr)->firstOrFail()
-                : $this->getCenter($request);
+            ? Center::abbreviation($abbr)->firstOrFail()
+            : $this->getCenter($request);
             Session::set('viewCenterId', $center->id);
         }
 
@@ -272,8 +272,8 @@ class ReportsController extends Controller
 
         if (!Session::has('viewRegionId')) {
             $region = $abbr
-                ? Region::abbreviation($abbr)->firstOrFail()
-                : $this->getRegion($request);
+            ? Region::abbreviation($abbr)->firstOrFail()
+            : $this->getRegion($request);
             Session::set('viewRegionId', $region->id);
         }
 
@@ -335,6 +335,9 @@ class ReportsController extends Controller
         if ($reportType == 'region') {
             $report = $globalReport ?: GlobalReport::reportingDate($reportingDate)->firstOrFail();
             $redirectUrl = App::make(GlobalReportController::class)->getUrl($report, $reportTarget);
+            if (!$reportViewUpdate) {
+                return App::make($controllerClass)->showForRegion($request, $report, $reportTarget);
+            }
         } else {
             $report = StatsReport::byCenter($reportTarget)
                 ->reportingDate($reportingDate)
@@ -346,8 +349,8 @@ class ReportsController extends Controller
         }
 
         return $reportViewUpdate
-            ? redirect($redirectUrl)
-            : App::make($controllerClass)->show($request, $report->id);
+        ? redirect($redirectUrl)
+        : App::make($controllerClass)->show($request, $report->id);
     }
 
     /**

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -375,7 +375,7 @@ class StatsReportController extends ReportDispatchAbstractController
         }
     }
 
-    public function runDispatcher(Request $request, $statsReport, $report, $extra)
+    public function runDispatcher(Request $request, $statsReport, $report, $extra = null)
     {
         $this->setCenter($statsReport->center);
         $this->context->setCenter($statsReport->center);

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -27,6 +27,7 @@ use TmlpStats\TmlpRegistrationData;
 class StatsReportController extends ReportDispatchAbstractController
 {
     const CACHE_TTL = 7 * 24 * 60;
+    protected $context;
 
     /**
      * Create a new controller instance.
@@ -35,6 +36,7 @@ class StatsReportController extends ReportDispatchAbstractController
     {
         $this->middleware('auth.token');
         $this->middleware('auth');
+        $this->context = App::make(Api\Context::class);
     }
 
     /**
@@ -143,6 +145,8 @@ class StatsReportController extends ReportDispatchAbstractController
     public function show(Request $request, $id)
     {
         $statsReport = StatsReport::findOrFail($id);
+        $this->context->setCenter($statsReport->center);
+        $this->context->setReportingDate($statsReport->reportingDate);
 
         $this->authorize('read', $statsReport);
 
@@ -371,10 +375,12 @@ class StatsReportController extends ReportDispatchAbstractController
         }
     }
 
-    public function runDispatcher(Request $request, $statsReport, $report)
+    public function runDispatcher(Request $request, $statsReport, $report, $extra)
     {
         $this->setCenter($statsReport->center);
+        $this->context->setCenter($statsReport->center);
         $this->setReportingDate($statsReport->reportingDate);
+        $this->context->setReportingDate($statsReport->reportingDate);
 
         if (!$statsReport->isValidated() && $report != 'results') {
             return '<p>This report did not pass validation. See Report Details for more information.</p>';

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -38,7 +38,7 @@ Route::get('statsreports/{id}/{report}', 'StatsReportController@dispatchReport')
 
 // Global Reports
 Route::resource('globalreports', 'GlobalReportController');
-Route::get('globalreports/{id}/{report}', 'GlobalReportController@dispatchReport');
+Route::get('globalreports/{id}/{report}/{regionAbbr?}', 'GlobalReportController@dispatchReport');
 
 // Report Tokens
 Route::resource('reporttokens', 'ReportTokenController');
@@ -61,7 +61,7 @@ Route::get('center/{abbr}', 'CenterController@dashboard');
 Route::resource('regions', 'RegionController');
 
 // Validate
-Route::get('validate', 'ImportController@indexValidateSheet');
+Route::get('validate', 'ImportController@indexValidateSheet')->name('validate');
 Route::post('validate', 'ImportController@validateSheet');
 
 // Import
@@ -69,6 +69,8 @@ Route::get('import', 'ImportController@indexImportSheet');
 Route::post('import', 'ImportController@importSheet');
 
 Route::match(['get', 'post'], 'home', 'HomeController@index');
+Route::match(['get', 'post'], 'home/{abbr}', 'HomeController@home');
+
 Route::get('/', 'WelcomeController@index');
 
 Route::post('home/clientsettings', function () {

--- a/src/app/Policies/UserPolicy.php
+++ b/src/app/Policies/UserPolicy.php
@@ -2,6 +2,8 @@
 
 namespace TmlpStats\Policies;
 
+use TmlpStats\User;
+
 class UserPolicy extends Policy
 {
 

--- a/src/app/Policies/UserPolicy.php
+++ b/src/app/Policies/UserPolicy.php
@@ -5,4 +5,12 @@ namespace TmlpStats\Policies;
 class UserPolicy extends Policy
 {
 
+    public function showReportButton(User $user)
+    {
+        if ($user->hasRole('readonly')) {
+            return ($user->reportToken && $user->reportToken->centerId);
+        }
+
+        return true;
+    }
 }

--- a/src/app/Region.php
+++ b/src/app/Region.php
@@ -1,6 +1,7 @@
 <?php
 namespace TmlpStats;
 
+use Carbon\Carbon;
 use Eloquence\Database\Traits\CamelCaseModel;
 use Illuminate\Database\Eloquent\Model;
 use TmlpStats\Traits\CachedRelationships;
@@ -104,5 +105,21 @@ class Region extends Model
     public function centers()
     {
         return $this->hasMany('TmlpStats\Center');
+    }
+
+    public function abbrLower()
+    {
+        return strtolower($this->abbreviation);
+    }
+
+    public function getUriRegionReport($reportingDate = null)
+    {
+        if ($reportingDate instanceof Carbon) {
+            $reportingDate = $reportingDate->toDateString();
+        }
+        return action('ReportsController@getRegionReport', [
+            'abbr' => $this->abbrLower(),
+            'date' => $reportingDate,
+        ]);
     }
 }

--- a/src/app/User.php
+++ b/src/app/User.php
@@ -4,14 +4,16 @@ namespace TmlpStats;
 use Eloquence\Database\Traits\CamelCaseModel;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\Access\Authorizable;
 use TmlpStats\Traits\CachedRelationships;
 
-class User extends Model implements AuthenticatableContract, CanResetPasswordContract
+class User extends Model implements AuthenticatableContract, CanResetPasswordContract, AuthorizableContract
 {
-    use Authenticatable, CanResetPassword, CamelCaseModel, CachedRelationships;
+    use Authenticatable, Authorizable, CanResetPassword, CamelCaseModel, CachedRelationships;
 
     /**
      * The database table used by the model.
@@ -37,9 +39,9 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     ];
 
     protected $casts = [
-        'active'                 => 'boolean',
+        'active' => 'boolean',
         'require_password_reset' => 'boolean',
-        'managed'                => 'boolean',
+        'managed' => 'boolean',
     ];
 
     protected $dates = [
@@ -78,8 +80,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             case 'phone':
             case 'center':
                 return $this->person
-                    ? $this->person->$name
-                    : null;
+                ? $this->person->$name
+                : null;
             default:
                 return parent::__get($name);
         }
@@ -101,8 +103,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
                 return $this->reportToken;
             case 'center':
                 return $this->reportToken
-                    ? $this->reportToken->center
-                    : null;
+                ? $this->reportToken->center
+                : null;
             case 'lastName':
             case 'phone':
                 return null;
@@ -136,8 +138,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function hasAccountability($name)
     {
         return $this->person
-            ? $this->person->hasAccountability($name)
-            : false;
+        ? $this->person->hasAccountability($name)
+        : false;
     }
 
     /**
@@ -161,13 +163,13 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     {
         if ($this->reportToken) {
             return $this->reportToken->center
-                ? $this->reportToken->center->region
-                : null;
+            ? $this->reportToken->center->region
+            : null;
         }
 
         return $this->person && $this->person->center
-            ? $this->person->center->region
-            : null;
+        ? $this->person->center->region
+        : null;
     }
 
     /**
@@ -181,7 +183,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return;
         }
 
-        $person           = $this->person;
+        $person = $this->person;
         $person->centerId = $center->id;
         $person->save();
     }
@@ -197,7 +199,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return;
         }
 
-        $person            = $this->person;
+        $person = $this->person;
         $person->firstName = $firstName;
         $person->save();
     }
@@ -213,7 +215,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return;
         }
 
-        $person           = $this->person;
+        $person = $this->person;
         $person->lastName = $lastName;
         $person->save();
     }
@@ -229,7 +231,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return;
         }
 
-        $person        = $this->person;
+        $person = $this->person;
         $person->phone = $phone;
         $person->save();
     }
@@ -245,7 +247,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return;
         }
 
-        $person        = $this->person;
+        $person = $this->person;
         $person->email = $email;
         $person->save();
     }
@@ -294,5 +296,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function role()
     {
         return $this->belongsTo('TmlpStats\Role');
+    }
+
+    // special case of 'can' builtin for a specific purpose of getting user-global perms
+    public function userCan($ability)
+    {
+        return $this->can($ability, $this);
     }
 }

--- a/src/resources/views/globalreports/show.blade.php
+++ b/src/resources/views/globalreports/show.blade.php
@@ -221,7 +221,7 @@
 
             // Load all of the pages
             $.each(pages, function (index, page) {
-                var url = "{{ url("/globalreports/{$globalReport->id}") }}/" + page + "?region={{$region->abbreviation}}";
+                var url = "{{ url("/globalreports/{$globalReport->id}") }}/" + page + "/{{$region->abbreviation}}";
                 var container = "#" + page + "-container";
 
                 // Display loader by default


### PR DESCRIPTION
* Add state management on the Context
* Controller actions now set context when it's really clear what it is
* Removed a lot of JS-based stuff for dealing with centers/regions
* Home controller now takes a region and will add a region on redirect
* "Regional Report" button doesn't flip to "center report" since it's
  not usually contextually useful - it just always goes to the
  regional report.
* Rewrote a lot of things to use `action()` instead of `url()`