### PR TITLE
Cleanup the date select the same way we did the other selects

### DIFF
--- a/src/app/Api/Context.php
+++ b/src/app/Api/Context.php
@@ -1,6 +1,7 @@
 <?php namespace TmlpStats\Api;
 
 use App;
+use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Http\Request;
 use TmlpStats as Models;
@@ -15,6 +16,10 @@ class Context
     protected $request = null;
     protected $region = null;
     protected $center = null;
+    protected $reportingDate = null;
+
+    protected $dateSelectAction = null;
+    protected $dateSelectActionParams = [];
 
     public function __construct(Guard $auth, Request $request)
     {
@@ -90,9 +95,35 @@ class Context
         return $value;
     }
 
-    /** Currently unused. */
     public function setReportingDate($reportingDate)
     {
-        // TODO
+        $this->reportingDate = $reportingDate;
+    }
+
+    public function getReportingDate()
+    {
+        $reportingDate = $this->reportingDate;
+        if (!$reportingDate) {
+            $reportingDate = App::make(Controller::class)->getReportingDate($this->request);
+        }
+        return $reportingDate;
+    }
+
+    public function setDateSelectAction($action, $params = [])
+    {
+        $this->dateSelectAction = $action;
+        $this->dateSelectActionParams = $params;
+    }
+
+    public function dateSelectAction($date)
+    {
+        if ($date instanceof Carbon) {
+            $date = $date->toDateString();
+        }
+        if ($this->dateSelectAction) {
+            $params = array_merge($this->dateSelectActionParams, ['date' => $date]);
+            return action($this->dateSelectAction, $params);
+        }
+        return null;
     }
 }

--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -172,4 +172,9 @@ class Center extends Model
             'date' => $reportingDate,
         ]);
     }
+
+    public function abbrLower()
+    {
+        return strtolower($this->abbreviation);
+    }
 }

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -147,7 +147,9 @@ class StatsReportController extends ReportDispatchAbstractController
         $statsReport = StatsReport::findOrFail($id);
         $this->context->setCenter($statsReport->center);
         $this->context->setReportingDate($statsReport->reportingDate);
-
+        $this->context->setDateSelectAction('ReportsController@getCenterReport', [
+            'abbr' => $statsReport->center->abbrLower(),
+        ]);
         $this->authorize('read', $statsReport);
 
         $sheetUrl = '';

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -69,7 +69,7 @@ Route::get('import', 'ImportController@indexImportSheet');
 Route::post('import', 'ImportController@importSheet');
 
 Route::match(['get', 'post'], 'home', 'HomeController@index');
-Route::match(['get', 'post'], 'home/{abbr}', 'HomeController@home');
+Route::match(['get', 'post'], 'home/{abbr}/{date?}', 'HomeController@home');
 
 Route::get('/', 'WelcomeController@index');
 

--- a/src/resources/views/globalreports/show.blade.php
+++ b/src/resources/views/globalreports/show.blade.php
@@ -221,7 +221,7 @@
 
             // Load all of the pages
             $.each(pages, function (index, page) {
-                var url = "{{ url("/globalreports/{$globalReport->id}") }}/" + page + "/{{$region->abbreviation}}";
+                var url = "{{ url("/globalreports/{$globalReport->id}") }}/" + page + "/{{$region->abbrLower()}}";
                 var container = "#" + page + "-container";
 
                 // Display loader by default
@@ -239,7 +239,7 @@
 
             $.each(batchedPages, function (index, batch) {
                 var query = batch.shift();
-                var url = "{{ url("/globalreports/{$globalReport->id}") }}/" + query + "?region={{$region->abbreviation}}";
+                var url = "{{ url("/globalreports/{$globalReport->id}") }}/" + query + "/{{$region->abbrLower()}}";
 
                 $.each(batch, function (i, name) {
                     $("#" + name + "-container").html($("#loader").html());

--- a/src/resources/views/partials/navbar.blade.php
+++ b/src/resources/views/partials/navbar.blade.php
@@ -6,6 +6,8 @@ if (!isset($regionSelectAction)) {
     $regionSelectAction = 'ReportsController@getRegionReport';
 }
 
+$dateSelectAction = $context->dateSelectAction('foo');
+$reportingDate = $context->getReportingDate();
 $regions = TmlpStats\Region::isGlobal()->get();
 $currentRegion = $context->getGlobalRegion(false);
 $reports = null;
@@ -22,8 +24,7 @@ if ($currentRegion != null) {
 
 $currentCenter = $context->getCenter(true);
 
-$reportingDate = App::make(TmlpStats\Http\Controllers\Controller::class)
-                    ->getReportingDate(Request::instance());
+
 $reportingDateString = ($reportingDate != null) ? $reportingDate->toDateString() : null;
 
 
@@ -89,6 +90,11 @@ $showNavCenterSelect = isset($showNavCenterSelect) ? $showNavCenterSelect : fals
                             </a>
                             <ul id="reportSelect" class="dropdown-menu" role="menu">
                                 @foreach ($reports as $report)
+                                    @if ($dateSelectAction)
+                                        <li class="menu-option">
+                                            <a href="{{ $context->dateSelectAction($report->reportingDate) }}">{{ $report->reportingDate->format('M j, Y')}}</a>
+                                        </li>
+                                    @else
                                     <li class="menu-option" data-url="{{ url("/reports/dates/setActive") }}"
                                         data-value="{{ $report->reportingDate->toDateString() }}">
                                         <a href="#">
@@ -100,6 +106,7 @@ $showNavCenterSelect = isset($showNavCenterSelect) ? $showNavCenterSelect : fals
                                             {{ $report->reportingDate->format('M j, Y')}}
                                         </a>
                                     </li>
+                                    @endif
                                 @endforeach
                             </ul>
                         </li>
@@ -193,6 +200,7 @@ $showNavCenterSelect = isset($showNavCenterSelect) ? $showNavCenterSelect : fals
             }
         );
 
+        @if (!$dateSelectAction)
         $("#reportSelect").on("click", "li.menu-option", function (e) {
             var url = $(this).attr('data-url');
             var data = {};
@@ -212,5 +220,6 @@ $showNavCenterSelect = isset($showNavCenterSelect) ? $showNavCenterSelect : fals
                 }
             });
         });
+        @endif
     });
 </script>


### PR DESCRIPTION
* Use URL building for the date selection whenever possible
* Put reporting date in context to eventually get rid of session-based
* Eliminate JS for most cases