### PR TITLE
Cache api requests

### DIFF
--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -154,8 +154,7 @@ class Application extends ApiBase
 
     public function getWeekData(Models\TmlpRegistration $application, Carbon $reportingDate)
     {
-        $cacheObjs = compact('application', 'reportingDate');
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache(compact('application', 'reportingDate'));
         if ($cached) {
             return $cached;
         }
@@ -181,7 +180,7 @@ class Application extends ApiBase
             'stats_report_id'      => $report->id,
         ])->load('registration.person', 'incomingQuarter', 'statsReport', 'withdrawCode', 'committedTeamMember.person');
 
-        $this->putCache($cacheObjs, $response);
+        $this->putCache($response);
 
         return $response;
     }

--- a/src/app/Api/Base/ApiBase.php
+++ b/src/app/Api/Base/ApiBase.php
@@ -12,16 +12,16 @@ use TmlpStats\Api\Parsers;
 
 class ApiBase
 {
-    const CACHE_TTL = 1440 * 14;
+    const CACHE_TTL = 1440 * 14; // 14 days
 
     /**
-     * Is cache enabled by default? Override this in derived classes
+     * Is cache enabled by default?
      * @var bool
      */
     protected $cacheEnabled = true;
 
     /**
-     * Methods to not cache. Override this in derived classes
+     * Methods to not cache.
      * @var array
      */
     protected $dontCache = [];
@@ -126,6 +126,12 @@ class ApiBase
         foreach ($objects as $name => $value) {
             if ($value instanceof Model) {
                 $value = $value->id;
+            } else if (is_array($value) || is_object($value)) {
+                if (is_array($value)) {
+                    // Canonicalize list by sorting
+                    ksort($value);
+                }
+                $value = json_encode($value);
             }
             $keyBase .= ":{$name}{$value}";
         }

--- a/src/app/Api/Base/ApiBase.php
+++ b/src/app/Api/Base/ApiBase.php
@@ -27,6 +27,12 @@ class ApiBase
     protected $dontCache = [];
 
     /**
+     * Working stack for keeping track of objects being cached
+     * @var array
+     */
+    protected $targetObjCache = [];
+
+    /**
      * Array of valid properties and their config.
      *  example:
      *      'firstName' => [
@@ -152,6 +158,7 @@ class ApiBase
             return null;
         }
         $objects['method'] = $method;
+        $this->targetObjCache[$method] = $objects;
 
         $tags = $this->getCacheTags($objects);
         $cacheKey = $this->getCacheKey($objects);
@@ -166,11 +173,16 @@ class ApiBase
      *
      * @return null
      */
-    public function putCache($objects, $value)
+    public function putCache($value, $objects = null)
     {
         $method = debug_backtrace()[1]['function'];
         if (!$this->useCache($method)) {
             return null;
+        }
+
+        if ($objects === null) {
+            $objects = isset($this->targetObjCache[$method]) ? $this->targetObjCache[$method] : [];
+            array_forget($this->targetObjCache, $method);
         }
         $objects['method'] = $method;
 

--- a/src/app/Api/Base/ApiBase.php
+++ b/src/app/Api/Base/ApiBase.php
@@ -1,14 +1,31 @@
 <?php
 namespace TmlpStats\Api\Base;
 
+use Cache;
 use Illuminate\Auth\Guard;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\ParameterBag;
+use TmlpStats as Models;
 use TmlpStats\Api;
 use TmlpStats\Api\Parsers;
 
 class ApiBase
 {
+    const CACHE_TTL = 1440 * 14;
+
+    /**
+     * Is cache enabled by default? Override this in derived classes
+     * @var bool
+     */
+    protected $cacheEnabled = true;
+
+    /**
+     * Methods to not cache. Override this in derived classes
+     * @var array
+     */
+    protected $dontCache = [];
+
     /**
      * Array of valid properties and their config.
      *  example:
@@ -27,6 +44,14 @@ class ApiBase
         $this->request = $request;
     }
 
+    /**
+     * Run parsers on demand.
+     *
+     * @param       $data
+     * @param array $requiredParams
+     *
+     * @return array
+     */
     public function parseInputs($data, $requiredParams = [])
     {
         $output = [];
@@ -46,5 +71,131 @@ class ApiBase
             $output[$key] = $parser->run($data, $key, $required);
         }
         return $output;
+    }
+
+    /**
+     * Determine if we should use the cache
+     *
+     * @param $report
+     *
+     * @return bool
+     */
+    public function useCache($report)
+    {
+        return $this->cacheEnabled
+            && env('API_USE_CACHE', $this->cacheEnabled)
+            && !in_array($report, $this->dontCache);
+    }
+
+    /**
+     * Get cache tags for provided list of objects
+     *
+     * Will ignore any value that is not an instance of Model
+     *
+     * @param array $objects
+     *
+     * @return array
+     */
+    public function getCacheTags($objects = [])
+    {
+        $tags = ["api"];
+        foreach ($objects as $name => $object) {
+            if (!($object instanceof Model)) {
+                continue;
+            }
+
+            $basename = lcfirst(class_basename(get_class($object)));
+            $tags[] = "{$basename}{$object->id}";
+        }
+        return $tags;
+    }
+
+    /**
+     * Get cache key from list of objects
+     *
+     * @param array $objects
+     *
+     * @return mixed
+     */
+    public function getCacheKey($objects = [])
+    {
+        // Canonicalize list by sorting
+        ksort($objects);
+
+        $keyBase = '';
+        foreach ($objects as $name => $value) {
+            if ($value instanceof Model) {
+                $value = $value->id;
+            }
+            $keyBase .= ":{$name}{$value}";
+        }
+        return md5($keyBase);
+    }
+
+    /**
+     * Return cache entry for list of objects
+     *
+     * @param $objects
+     *
+     * @return null
+     */
+    public function checkCache($objects)
+    {
+        $method = debug_backtrace()[1]['function'];
+        if (!$this->useCache($method)) {
+            return null;
+        }
+        $objects['method'] = $method;
+
+        $tags = $this->getCacheTags($objects);
+        $cacheKey = $this->getCacheKey($objects);
+        return Cache::tags($tags)->get($cacheKey);
+    }
+
+    /**
+     * Create cache entry for list of objects
+     *
+     * @param $objects
+     * @param $value
+     *
+     * @return null
+     */
+    public function putCache($objects, $value)
+    {
+        $method = debug_backtrace()[1]['function'];
+        if (!$this->useCache($method)) {
+            return null;
+        }
+        $objects['method'] = $method;
+
+        $tags = $this->getCacheTags($objects);
+        $cacheKey = $this->getCacheKey($objects);
+        Cache::tags($tags)->put($cacheKey, $value, static::CACHE_TTL);
+    }
+
+    /**
+     * Merge arrays of objects together. Works like array_merge but will handle non-array input
+     *
+     * Useful when input may be null instead of and empty array
+     *
+     * @param $arr1
+     * @param $arr2
+     *
+     * @return mixed
+     */
+    public function merge($arr1, $arr2)
+    {
+        if ($arr1 === null) {
+            $arr1 = [];
+        } else if (!is_array($arr1)) {
+            $arr1 = [$arr1];
+        }
+        if ($arr2 === null) {
+            $arr2 = [];
+        } else if (!is_array($arr2)) {
+            $arr2 = [$arr2];
+        }
+
+        return array_merge($arr1, $arr2);
     }
 }

--- a/src/app/Api/GlobalReport.php
+++ b/src/app/Api/GlobalReport.php
@@ -12,8 +12,7 @@ class GlobalReport extends ApiBase
 {
     public function getRating(Models\GlobalReport $report, Models\Region $region)
     {
-        $cacheObjs = compact('report', 'region');
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache(compact('report', 'region'));
         if ($cached) {
             return $cached;
         }
@@ -32,15 +31,14 @@ class GlobalReport extends ApiBase
         $data['summary']['points'] = $weeklyData[$dateString]['points']['total'];
         $data['summary']['rating'] = $weeklyData[$dateString]['rating'];
 
-        $this->putCache($cacheObjs, $data);
+        $this->putCache($data);
 
         return $data;
     }
 
     public function getQuarterScoreboard(Models\GlobalReport $report, Models\Region $region)
     {
-        $cacheObjs = compact('report', 'region');
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache(compact('report', 'region'));
         if ($cached) {
             return $cached;
         }
@@ -99,15 +97,14 @@ class GlobalReport extends ApiBase
         $a = new Arrangements\GamesByWeek($scoreboardData);
         $weeklyData = $a->compose();
 
-        $this->putCache($cacheObjs, $weeklyData['reportData']);
+        $this->putCache($weeklyData['reportData']);
 
         return $weeklyData['reportData'];
     }
 
     public function getWeekScoreboard(Models\GlobalReport $report, Models\Region $region, Carbon $futureDate = null)
     {
-        $cacheObjs = compact('report', 'region');
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache(compact('report', 'region'));
         if ($cached) {
             return $cached;
         }
@@ -121,15 +118,14 @@ class GlobalReport extends ApiBase
             $reportData = $scoreboardData[$dateStr];
         }
 
-        $this->putCache($cacheObjs, $reportData);
+        $this->putCache($reportData);
 
         return $reportData;
     }
 
     public function getWeekScoreboardByCenter(Models\GlobalReport $report, Models\Region $region, $options = [])
     {
-        $cacheObjs = $this->merge(compact('report', 'region'), $options);
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache($this->merge(compact('report', 'region'), $options));
         if ($cached) {
             return $cached;
         }
@@ -157,15 +153,14 @@ class GlobalReport extends ApiBase
             $reportData[$centerName] = $centerStatsData[$dateStr];
         }
 
-        $this->putCache($cacheObjs, $reportData);
+        $this->putCache($reportData);
 
         return $reportData;
     }
 
     public function getApplicationsListByCenter(Models\GlobalReport $report, Models\Region $region, $options = [])
     {
-        $cacheObjs = $this->merge(compact('report', 'region'), $options);
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache($this->merge(compact('report', 'region'), $options));
         if ($cached) {
             return $cached;
         }
@@ -189,7 +184,7 @@ class GlobalReport extends ApiBase
             }
         }
 
-        $this->putCache($cacheObjs, $registrations);
+        $this->putCache($registrations);
 
         return $registrations;
     }

--- a/src/app/Api/LocalReport.php
+++ b/src/app/Api/LocalReport.php
@@ -13,8 +13,7 @@ class LocalReport extends ApiBase
 {
     public function getQuarterScoreboard(Models\StatsReport $statsReport, $options = [])
     {
-        $cacheObjs = $this->merge(compact('statsReport'), $options);
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache($this->merge(compact('statsReport'), $options));
         if (false && $cached) {
             return $cached;
         }
@@ -68,7 +67,7 @@ class LocalReport extends ApiBase
                 $response = array_flatten($scoreboardData);
             }
 
-            $this->putCache($cacheObjs, $response);
+            $this->putCache($response);
 
             return $response;
         }
@@ -76,15 +75,14 @@ class LocalReport extends ApiBase
         $a = new Arrangements\GamesByWeek(array_flatten($scoreboardData));
         $centerStatsData = $a->compose();
 
-        $this->putCache($cacheObjs, $centerStatsData['reportData']);
+        $this->putCache($centerStatsData['reportData']);
 
         return $centerStatsData['reportData'];
     }
 
     public function getWeekScoreboard(Models\StatsReport $statsReport)
     {
-        $cacheObjs = compact('statsReport');
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache(compact('statsReport'));
         if (false && $cached) {
             return $cached;
         }
@@ -98,15 +96,14 @@ class LocalReport extends ApiBase
             $response = $scoreboardData[$dateStr];
         }
 
-        $this->putCache($cacheObjs, $response);
+        $this->putCache($response);
 
         return $response;
     }
 
     public function getApplicationsList(Models\StatsReport $statsReport, $options = [])
     {
-        $cacheObjs = $this->merge(compact('statsReport'), $options);
-        $cached = $this->checkCache($cacheObjs);
+        $cached = $this->checkCache($this->merge(compact('statsReport'), $options));
         if (false && $cached) {
             return $cached;
         }
@@ -119,7 +116,7 @@ class LocalReport extends ApiBase
         if (!$registrations) {
             return [];
         } else if ($returnUnprocessed) {
-            $this->putCache($cacheObjs, $registrations);
+            $this->putCache($registrations);
             return $registrations;
         }
 
@@ -129,7 +126,7 @@ class LocalReport extends ApiBase
         ]);
         $data = $a->compose();
 
-        $this->putCache($cacheObjs, $data['reportData']);
+        $this->putCache($data['reportData']);
 
         return $data['reportData'];
     }

--- a/src/app/Console/Commands/FlushCacheTagCommand.php
+++ b/src/app/Console/Commands/FlushCacheTagCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace TmlpStats\Console\Commands;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Command;
+
+class FlushCacheTagCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:clear-tag {tag}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear specified tag from cache';
+
+    /**
+     * The cache manager instance.
+     *
+     * @var \Illuminate\Cache\CacheManager
+     */
+    protected $cache;
+
+    /**
+     * Create a new command instance.
+     *
+     */
+    public function __construct(CacheManager $cache)
+    {
+        parent::__construct();
+        $this->cache = $cache;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $tag = $this->argument('tag');
+
+        $this->cache->store()->tags($tag)->flush();
+
+        $this->info("{$tag} cleared from cache!");
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends ConsoleKernel {
         Commands\FlushReportsCacheCommand::class,
         Commands\SanitizeDb::class,
         Commands\MergeDuplicatePeople::class,
+        Commands\FlushCacheTagCommand::class,
     ];
 
     /**


### PR DESCRIPTION
Work In Progress.

Cache api requests instead of controller views. Fixes several problems
- repeat lookups on the first run
- hidden links in html are user specific. When using the cache, everyone see's the first person's links.
- faster js fetches from the api