### PR TITLE
Fix an issue with GITW/TDO summaries

### DIFF
--- a/src/app/Reports/Arrangements/TeamMemberWeeklyValue.php
+++ b/src/app/Reports/Arrangements/TeamMemberWeeklyValue.php
@@ -36,6 +36,10 @@ abstract class TeamMemberWeeklyValue extends BaseArrangement
                 }
                 if ($data->withdrawCodeId !== null) {
                     $member['withdrawn'] = true;
+                } else {
+                    // We need this to allow for team members that were withdrawn then
+                    // rejoined team within the same quarter. Kind of a special case.
+                    $member['withdrawn'] = false;
                 }
                 if (!$data->xferOut) {
                     $member[$date] = [


### PR DESCRIPTION
When someone withdraws, then rejoins within the same quarter, we need to update the withdraw setting so they are not removed from the list permanently