### PR TITLE
Fix form fields inappropriately modified by autofills

### DIFF
--- a/src/public/js/tmlpstats.js
+++ b/src/public/js/tmlpstats.js
@@ -53,6 +53,28 @@ function initDataTables(options, tableClass) {
 }
 
 /**
+ * Super gross workaround for Chrome not respecting autocomplete settings.
+ * Only using this to prevent autofilling the user's name and email into forms that
+ * take info about a different person
+ */
+$(function() {
+    $('form[autocomplete="off"] input, input[autocomplete="off"]').each(function () {
+
+        var input = this;
+        var name = $(input).attr('name');
+        var id = $(input).attr('id');
+
+        $(input).removeAttr('name');
+        $(input).removeAttr('id');
+
+        setTimeout(function () {
+            $(input).attr('name', name);
+            $(input).attr('id', id);
+        }, 1);
+    });
+});
+
+/**
  * JS API for TMLP things.
  *
  * This API is designed to be optimized by javascript optimizing compilers

--- a/src/resources/views/admin/centers/edit.blade.php
+++ b/src/resources/views/admin/centers/edit.blade.php
@@ -5,7 +5,7 @@
 
 @include('errors.list')
 
-{!! Form::model($center, ['url' => 'admin/centers/' . $center->abbreviation, 'method' => 'PUT', 'class' => 'form-horizontal']) !!}
+{!! Form::model($center, ['url' => 'admin/centers/' . $center->abbreviation, 'method' => 'PUT', 'class' => 'form-horizontal', 'autocomplete' => 'off']) !!}
 
     @include('admin.centers.form', ['submitButtonText' => 'Update'])
 

--- a/src/resources/views/admin/centers/form.blade.php
+++ b/src/resources/views/admin/centers/form.blade.php
@@ -3,7 +3,7 @@
     <div class="form-group">
         {!! Form::label('name', 'Name:', ['class' => 'col-sm-2 control-label']) !!}
         <div class="col-sm-5">
-            {!! Form::text('name', null, ['class' => 'form-control']) !!}
+            {!! Form::text('name', null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
         </div>
     </div>
 
@@ -38,7 +38,7 @@
     <div class="form-group">
         {!! Form::label('timezone', 'Timezone:', ['class' => 'col-sm-2 control-label']) !!}
         <div class="col-sm-5">
-            @include('partials.forms.timezones', compact('timezones', 'selectedTimezone'))
+            @include('partials.forms.timezones')
         </div>
     </div>
 

--- a/src/resources/views/invites/create.blade.php
+++ b/src/resources/views/invites/create.blade.php
@@ -5,7 +5,7 @@
 
     @include('errors.list')
 
-    {!! Form::open(['url' => '/users/invites', 'class' => 'form-horizontal']) !!}
+    {!! Form::open(['url' => '/users/invites', 'class' => 'form-horizontal', 'autocomplete' => 'off']) !!}
 
     @include('invites.form', ['submitButtonText' => 'Create', 'invite' => null, 'roles' => $roles])
 

--- a/src/resources/views/invites/edit.blade.php
+++ b/src/resources/views/invites/edit.blade.php
@@ -5,7 +5,7 @@
 
     @include('errors.list')
 
-    {!! Form::model($invite, ['url' => "/users/invites/{$invite->id}", 'method' => 'PUT', 'class' => 'form-horizontal']) !!}
+    {!! Form::model($invite, ['url' => "/users/invites/{$invite->id}", 'method' => 'PUT', 'class' => 'form-horizontal', 'autocomplete' => 'off']) !!}
 
     @include('invites.form', ['submitButtonText' => 'Update', 'roles' => $roles])
 

--- a/src/resources/views/invites/form.blade.php
+++ b/src/resources/views/invites/form.blade.php
@@ -3,28 +3,28 @@
 <div class="form-group">
     {!! Form::label('first_name', 'First Name:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::text('first_name', $invite ? $invite->firstName : null, ['class' => 'form-control']) !!}
+        {!! Form::text('first_name', $invite ? $invite->firstName : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 
 <div class="form-group">
     {!! Form::label('last_name', 'Last Name:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::text('last_name', $invite ? $invite->lastName : null, ['class' => 'form-control']) !!}
+        {!! Form::text('last_name', $invite ? $invite->lastName : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 
 <div class="form-group">
     {!! Form::label('email', 'Email:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::email('email', $invite ? $invite->email : null, ['class' => 'form-control']) !!}
+        {!! Form::email('email', $invite ? $invite->email : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 
 <div class="form-group">
     {!! Form::label('phone', 'Phone:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::input('tel', 'phone', $invite ? $invite->phone : null, ['class' => 'form-control']) !!}
+        {!! Form::input('tel', 'phone', $invite ? $invite->phone : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 

--- a/src/resources/views/partials/forms/timezones.blade.php
+++ b/src/resources/views/partials/forms/timezones.blade.php
@@ -1,6 +1,7 @@
-{!! Form::select('timezone',
-   isset($timezones)
-       ? $timezones
-       : DateTimeZone::listIdentifiers(),
-   isset($selectedTimezone) ? $selectedTimezone : null,
+<?php
+    $name = isset($elementName) ? $elementName : 'timezone';
+    $timezones = isset($timezones) ? $timezones : DateTimeZone::listIdentifiers();
+    $selected = isset($selectedTimezone) ? $selectedTimezone : null;
+?>
+{!! Form::select($name, $timezones, $selected,
    ['class' => 'form-control', 'onchange' => (isset($autoSubmit) && $autoSubmit) ? 'this.form.submit()' : '']) !!}

--- a/src/resources/views/partials/forms/timezones.blade.php
+++ b/src/resources/views/partials/forms/timezones.blade.php
@@ -1,7 +1,7 @@
 <?php
-    $name = isset($elementName) ? $elementName : 'timezone';
+    $elementName = isset($elementName) ? $elementName : 'timezone';
     $timezones = isset($timezones) ? $timezones : DateTimeZone::listIdentifiers();
-    $selected = isset($selectedTimezone) ? $selectedTimezone : null;
+    $selectedTimezone = isset($selectedTimezone) ? $selectedTimezone : null;
 ?>
-{!! Form::select($name, $timezones, $selected,
+{!! Form::select($elementName, $timezones, $selectedTimezone,
    ['class' => 'form-control', 'onchange' => (isset($autoSubmit) && $autoSubmit) ? 'this.form.submit()' : '']) !!}

--- a/src/resources/views/users/create.blade.php
+++ b/src/resources/views/users/create.blade.php
@@ -5,7 +5,7 @@
 
 @include('errors.list')
 
-{!! Form::open(['url' => '/admin/users', 'class' => 'form-horizontal']) !!}
+{!! Form::open(['url' => '/admin/users', 'class' => 'form-horizontal', 'autocomplete' => 'off']) !!}
 
     @include('users.form', ['submitButtonText' => 'Create', 'user' => null, 'roles' => $roles])
 

--- a/src/resources/views/users/edit.blade.php
+++ b/src/resources/views/users/edit.blade.php
@@ -6,7 +6,7 @@
 
 @include('errors.list')
 
-{!! Form::model($user, ['url' => "/admin/users/{$user->id}", 'method' => 'PUT', 'class' => 'form-horizontal']) !!}
+{!! Form::model($user, ['url' => "/admin/users/{$user->id}", 'method' => 'PUT', 'class' => 'form-horizontal', 'autocomplete' => 'off']) !!}
 
     @include('users.form', ['submitButtonText' => 'Update', 'roles' => $roles])
 

--- a/src/resources/views/users/form.blade.php
+++ b/src/resources/views/users/form.blade.php
@@ -3,28 +3,28 @@
 <div class="form-group">
     {!! Form::label('first_name', 'First Name:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::text('first_name', $user ? $user->firstName : null, ['class' => 'form-control']) !!}
+        {!! Form::text('first_name', $user ? $user->firstName : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 
 <div class="form-group">
     {!! Form::label('last_name', 'Last Name:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::text('last_name', $user ? $user->lastName : null, ['class' => 'form-control']) !!}
+        {!! Form::text('last_name', $user ? $user->lastName : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 
 <div class="form-group">
     {!! Form::label('email', 'Email:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::email('email', $user ? $user->email : null, ['class' => 'form-control']) !!}
+        {!! Form::email('email', $user ? $user->email : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 
 <div class="form-group">
     {!! Form::label('phone', 'Phone:', ['class' => 'col-sm-2 control-label']) !!}
     <div class="col-sm-5">
-        {!! Form::input('tel', 'phone', $user ? $user->phone : null, ['class' => 'form-control']) !!}
+        {!! Form::input('tel', 'phone', $user ? $user->phone : null, ['class' => 'form-control', 'autocomplete' => 'off']) !!}
     </div>
 </div>
 


### PR DESCRIPTION
There are several form fields that are commonly autofilled (email, first_name, name, etc). Most of the time in this app we don't want to autofill forms because we are submitting information about someone else.

Unfortunately, Chrome totally ignores autocomplete = "off", so this PR uses JS to trick chrome.

The other way to fix it is by changing the field names in the form. The problem with this is it breaks the Form class's auto fill of selected/default elements. Rather than making changes in multiple controllers, updating half a dozen blades and redoing all of the logic to fill in the input default values, I opted for the gross js.