### PR TITLE
Fix report submit to only mark it as submitted if validation succeeds(doesn't have to pass)

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -289,15 +289,15 @@ class StatsReportController extends ReportDispatchAbstractController
                 }
                 $importer->saveReport();
                 $sheet = $importer->getResults();
+
+                $statsReport->submittedAt = Carbon::now();
+                $statsReport->submitComment = Input::get('comment', null);
+                $statsReport->locked = true;
             } catch (Exception $e) {
                 Log::error("Error validating sheet: " . $e->getMessage() . "\n" . $e->getTraceAsString());
             }
 
-            $statsReport->submittedAt = Carbon::now();
-            $statsReport->submitComment = Input::get('comment', null);
-            $statsReport->locked = true;
-
-            if ($statsReport->save()) {
+            if ($statsReport->isDirty() && $statsReport->save()) {
                 // Cache the validation results so we don't have to regenerate
                 $cacheKey = "statsReport{$id}:results";
                 Cache::tags(["statsReport{$id}"])->put($cacheKey, $sheet, static::CACHE_TTL);

--- a/src/app/Import/ImportManager.php
+++ b/src/app/Import/ImportManager.php
@@ -124,13 +124,13 @@ class ImportManager
                         throw new Exception("The file you uploaded, '{$fileName}', looks like a special Excel temporary file. Please look for a file that does not start with '~$'");
                     }
 
-                    throw new Exception("There was an error processing '$fileName': " . $e->getMessage());
+                    throw new Exception("There was an error processing '{$fileName}': " . $e->getMessage());
                 }
 
                 $user         = Auth::user()->email;
                 $errorCount   = count($sheet['errors']);
                 $warningCount = count($sheet['warnings']);
-                Log::info("{$user} submitted sheet for {$sheet['center']} with {$errorCount} errors and {$warningCount} warnings.");
+                Log::info("{$user} validated sheet for {$sheet['center']} with {$errorCount} errors and {$warningCount} warnings.");
 
                 if (isset($sheet['statsReportId'])) {
 
@@ -140,6 +140,8 @@ class ImportManager
                     if (!$saveReport) {
                         $cacheKey = "statsReport{$sheet['statsReportId']}:importdata";
                         Cache::put($cacheKey, $importer, 10);
+                    } else {
+                        Log::info("User {$user} submitted statsReport {$sheet['statsReportId']}");
                     }
 
                     if ($sheet['submittedAt']) {


### PR DESCRIPTION
This fixes an issue where if an exception was thrown while validating/saving a report during submit, it would be marked as submitted and emails sent, but it would not be included on the global report.

Also added better logging around submits