### PR TITLE
Add validation path for API submission

### DIFF
--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -186,15 +186,14 @@ class Application extends ApiBase
         }
         $submissionData->store($center, $reportingDate, $teamApp);
 
-        // TODO: pass a real stats report?
-        // $report = new Models\StatsReport(['reportingDate' => $reportingDate]);
-        // $validationResults = $this->validateObject($report, $teamApp, $appId);
+        $report = LocalReport::getStatsReport($center, $reportingDate);
+        $validationResults = $this->validateObject($report, $teamApp, $appId);
 
         return [
             'success' => true,
             'storedId' => $appId,
-            // 'valid' => $validationResults['valid'],
-            // 'messages' => $validationResults['messages'],
+            'valid' => $validationResults['valid'],
+            'messages' => $validationResults['messages'],
         ];
     }
 

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -186,7 +186,16 @@ class Application extends ApiBase
         }
         $submissionData->store($center, $reportingDate, $teamApp);
 
-        return ['success' => true, 'storedId' => $appId];
+        // TODO: pass a real stats report?
+        // $report = new Models\StatsReport(['reportingDate' => $reportingDate]);
+        // $validationResults = $this->validateObject($report, $teamApp, $appId);
+
+        return [
+            'success' => true,
+            'storedId' => $appId,
+            // 'valid' => $validationResults['valid'],
+            // 'messages' => $validationResults['messages'],
+        ];
     }
 
     /**
@@ -197,7 +206,6 @@ class Application extends ApiBase
      */
     public function commitStashedApp(Models\TmlpRegistration $application, Carbon $reportingDate, Domain\TeamApplication $data)
     {
-
         $report = LocalReport::getStatsReport($application->center, $reportingDate);
 
         $applicationData = Models\TmlpRegistrationData::firstOrCreate([

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -168,7 +168,7 @@ class Application extends ApiBase
     public function stash(Models\Center $center, Carbon $reportingDate, array $data)
     {
         $submissionData = App::make(SubmissionData::class);
-        $appId = array_get($data, 'tmlpRegistrationId', null);
+        $appId = array_get($data, 'tmlpRegistration', null);
         if (is_numeric($appId)) {
             $appId = intval($appId);
         }
@@ -180,7 +180,7 @@ class Application extends ApiBase
         } else {
             if (!$appId) {
                 $appId = $submissionData->generateId();
-                $data['tmlpRegistrationId'] = $appId;
+                $data['tmlpRegistration'] = $appId;
             }
             $teamApp = Domain\TeamApplication::fromArray($data);
         }

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -161,9 +161,9 @@ class Application extends ApiBase
 
     /**
      * Stash information about a registration (combined name data and application progress data) to be used for later validation.
-     * @param  TmlpRegistration $application   The application we're stashing data about.
-     * @param  Carbon           $reportingDate Reporting date
-     * @param  array            $data          Information to use to construct a TeamApplication.
+     * @param  Center  $center         The courses's center
+     * @param  Carbon  $reportingDate  Reporting date
+     * @param  array   $data           Information to use to construct a TeamApplication.
      */
     public function stash(Models\Center $center, Carbon $reportingDate, array $data)
     {

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -168,7 +168,7 @@ class Application extends ApiBase
     public function stash(Models\Center $center, Carbon $reportingDate, array $data)
     {
         $submissionData = App::make(SubmissionData::class);
-        $appId = array_get($data, 'tmlpRegistration', null);
+        $appId = array_get($data, 'id', null);
         if (is_numeric($appId)) {
             $appId = intval($appId);
         }
@@ -180,7 +180,7 @@ class Application extends ApiBase
         } else {
             if (!$appId) {
                 $appId = $submissionData->generateId();
-                $data['tmlpRegistration'] = $appId;
+                $data['id'] = $appId;
             }
             $teamApp = Domain\TeamApplication::fromArray($data);
         }

--- a/src/app/Api/Base/ApiBase.php
+++ b/src/app/Api/Base/ApiBase.php
@@ -5,8 +5,11 @@ use Cache;
 use Illuminate\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use TmlpStats as Models;
 use TmlpStats\Api;
 use TmlpStats\Api\Parsers;
+use TmlpStats\Domain\ParserDomain;
+use TmlpStats\Validate\ApiValidationManager;
 
 class ApiBase
 {
@@ -204,5 +207,17 @@ class ApiBase
         }
 
         return array_merge($arr1, $arr2);
+    }
+
+    public function validateObject(Models\StatsReport $statsReport, ParserDomain $object, $id = null)
+    {
+        $validator = new ApiValidationManager($statsReport);
+
+        $success = $validator->runOne($object, $id);
+
+        return [
+            'valid' => $success,
+            'messages' => $validator->getMessages(),
+        ];
     }
 }

--- a/src/app/Api/Course.php
+++ b/src/app/Api/Course.php
@@ -1,6 +1,7 @@
 <?php
 namespace TmlpStats\Api;
 
+use App;
 use Carbon\Carbon;
 use TmlpStats as Models;
 use TmlpStats\Api\Base\ApiBase;
@@ -15,7 +16,6 @@ class Course extends ApiBase
     public function create(array $data)
     {
         $input = Domain\Course::fromArray($data, ['center', 'startDate', 'type']);
-        $input->type = strtoupper($input->type);
 
         $courseData = [
             'center_id' => $input->center->id,
@@ -60,7 +60,7 @@ class Course extends ApiBase
         return $course->load('center');
     }
 
-    public function allForCenter(Models\Center $center, Carbon $reportingDate = null)
+    public function allForCenter(Models\Center $center, $includeInProgress = false, Carbon $reportingDate = null)
     {
         if ($reportingDate === null) {
             $reportingDate = LocalReport::getReportingDate($center);
@@ -79,6 +79,7 @@ class Course extends ApiBase
             ->get();
 
         $allCourses = [];
+
         foreach ($reports as $report) {
             foreach ($report->courseData as $courseData) {
                 // Store indexed here so we end up with only the most recent one for each course
@@ -94,6 +95,14 @@ class Course extends ApiBase
             }
 
             $allCourses[$courseData->courseId] = Domain\Course::fromModel($courseData);
+        }
+
+        if ($includeInProgress) {
+            $submissionData = App::make(SubmissionData::class);
+            $found = $submissionData->allForType($center, $reportingDate, Domain\Course::class);
+            foreach ($found as $courseData) {
+                $allCourses[$courseData->courseId] = $courseData;
+            }
         }
 
         usort($allCourses, function ($a, $b) {
@@ -150,7 +159,51 @@ class Course extends ApiBase
         return $response->load('course', 'course.center', 'statsReport');
     }
 
-    public function setWeekData(Models\Course $course, Carbon $reportingDate, array $data)
+    /**
+     * Stash information about a registration (combined name data and course progress data) to be used for later validation.
+     * @param  Center $center   The courses's center
+     * @param  Carbon           $reportingDate Reporting date
+     * @param  array            $data          Information to use to construct a Course.
+     */
+    public function stash(Models\Center $center, Carbon $reportingDate, array $data)
+    {
+        $submissionData = App::make(SubmissionData::class);
+        $courseId = array_get($data, 'id', null);
+        if (is_numeric($courseId)) {
+            $courseId = intval($courseId);
+        }
+
+        if ($courseId !== null && $courseId > 0) {
+            $courseModel = Models\Course::findOrFail($courseId);
+            $course = Domain\Course::fromModel(null, $courseModel);
+            $course->updateFromArray($data);
+        } else {
+            if (!$courseId) {
+                $courseId = $submissionData->generateId();
+                $data['id'] = $courseId;
+            }
+            $course = Domain\Course::fromArray($data);
+        }
+        $submissionData->store($center, $reportingDate, $course);
+
+        $report = LocalReport::getStatsReport($center, $reportingDate);
+        $validationResults = $this->validateObject($report, $course, $courseId);
+
+        return [
+            'success' => true,
+            'storedId' => $courseId,
+            'valid' => $validationResults['valid'],
+            'messages' => $validationResults['messages'],
+        ];
+    }
+
+    /**
+     * Commit week data to the database. Will be performed during validation to write the domain object into the DB
+     * @param  Models\Course  $application   The application we are working with.
+     * @param  Carbon         $reportingDate [description]
+     * @param  Domain\Course  $data          [description]
+     */
+    public function commitStashedApp(Models\Course $course, Carbon $reportingDate, array $data)
     {
         if ($reportingDate->dayOfWeek !== Carbon::FRIDAY) {
             throw new ApiExceptions\BadRequestException('Reporting date must be a Friday.');

--- a/src/app/Api/Course.php
+++ b/src/app/Api/Course.php
@@ -75,7 +75,7 @@ class Course extends ApiBase
             ->official()
             ->where('reporting_date', '<=', $reportingDate)
             ->orderBy('reporting_date', 'asc')
-            ->with('tmlpRegistrationData')
+            ->with('courseData')
             ->get();
 
         $allCourses = [];

--- a/src/app/Api/SubmissionData.php
+++ b/src/app/Api/SubmissionData.php
@@ -22,6 +22,11 @@ class SubmissionData extends AuthenticatedApiBase
             'class' => Domain\TeamApplication::class,
             'idAttr' => 'id',
         ],
+        [
+            'key' => 'course',
+            'class' => Domain\Course::class,
+            'idAttr' => 'id',
+        ],
     ];
 
     protected $keyTypeMapping = [];

--- a/src/app/Api/SubmissionData.php
+++ b/src/app/Api/SubmissionData.php
@@ -20,7 +20,7 @@ class SubmissionData extends AuthenticatedApiBase
         [
             'key' => 'application',
             'class' => Domain\TeamApplication::class,
-            'idAttr' => 'tmlpRegistrationId',
+            'idAttr' => 'id',
         ],
     ];
 

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -186,8 +186,8 @@ class TeamMember extends ApiBase
 
         foreach ($data as $property => $value) {
             if ($this->validProperties[$property]['owner'] == 'teamMemberData') {
-                if (($teamMemberData->$property instanceof Carbon) && Carbon::parse($value)
-                                                                            ->ne($teamMemberData->$property)
+                if (($teamMemberData->$property instanceof Carbon)
+                    && Carbon::parse($value)->ne($teamMemberData->$property)
                 ) {
                     $teamMemberData->$property = Carbon::parse($value)->startOfDay();
                 } else if ($teamMemberData->$property !== $value) {

--- a/src/app/Domain/Course.php
+++ b/src/app/Domain/Course.php
@@ -12,6 +12,7 @@ class Course extends ParserDomain
         'center' => [
             'owner' => 'course',
             'type' => 'Center',
+            'assignId' => true,
         ],
         'startDate' => [
             'owner' => 'course',
@@ -25,7 +26,7 @@ class Course extends ParserDomain
             'owner' => 'course',
             'type' => 'string',
         ],
-        'courseId' => [
+        'id' => [
             'owner' => 'courseData',
             'type' => 'int',
         ],
@@ -116,10 +117,12 @@ class Course extends ParserDomain
                     $obj->$k = $course->$k;
                     break;
                 case 'courseData':
-                    $obj->$k = $courseData->$k;
+                    if ($courseData) {
+                        $obj->$k = $courseData->$k;
+                    }
             }
         }
-        $obj->courseId = $course->id;
+        $obj->id = $course->id;
 
         return $obj;
     }

--- a/src/app/Domain/ParserDomain.php
+++ b/src/app/Domain/ParserDomain.php
@@ -107,16 +107,6 @@ class ParserDomain implements Arrayable, \JsonSerializable
 
     public function __get($key)
     {
-        if (!array_key_exists($key, static::$validProperties) && !array_key_exists($key, $this->_values)) {
-            $trace = debug_backtrace();
-            trigger_error(
-                'Undefined property via __get(): ' . $key .
-                ' in ' . $trace[0]['file'] .
-                ' on line ' . $trace[0]['line'],
-                E_USER_NOTICE
-            );
-        }
-
         if (isset($this->_values[$key])) {
             return $this->_values[$key];
         } else {

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -123,7 +123,7 @@ class TeamApplication extends ParserDomain
                     }
             }
         }
-        $obj->tmlpRegistration = $application->id;
+        $obj->tmlpRegistration = $application;
 
         return $obj;
     }

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -38,9 +38,10 @@ class TeamApplication extends ParserDomain
             'owner' => 'application',
             'type' => 'bool',
         ],
-        'tmlpRegistrationId' => [
+        'tmlpRegistration' => [
             'owner' => 'applicationData',
-            'type' => 'int',
+            'type' => 'Application',
+            'assignId' => true,
         ],
         'appOutDate' => [
             'owner' => 'applicationData',
@@ -58,13 +59,15 @@ class TeamApplication extends ParserDomain
             'owner' => 'applicationData',
             'type' => 'date',
         ],
-        'withdrawCodeId' => [
+        'withdrawCode' => [
             'owner' => 'applicationData',
-            'type' => 'int', // TODO: validate withdrawCode from the ID
+            'type' => 'WithdrawCode',
+            'assignId' => true,
         ],
-        'committedTeamMemberId' => [
+        'committedTeamMember' => [
             'owner' => 'applicationData',
-            'type' => 'int',
+            'type' => 'TeamMember',
+            'assignId' => true,
         ],
         'incomingQuarter' => [
             'owner' => 'applicationData',
@@ -120,7 +123,7 @@ class TeamApplication extends ParserDomain
                     }
             }
         }
-        $obj->tmlpRegistrationId = $application->id;
+        $obj->tmlpRegistration = $application->id;
 
         return $obj;
     }

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -38,10 +38,9 @@ class TeamApplication extends ParserDomain
             'owner' => 'application',
             'type' => 'bool',
         ],
-        'tmlpRegistration' => [
+        'id' => [
             'owner' => 'applicationData',
-            'type' => 'Application',
-            'assignId' => true,
+            'type' => 'int',
         ],
         'appOutDate' => [
             'owner' => 'applicationData',
@@ -123,7 +122,7 @@ class TeamApplication extends ParserDomain
                     }
             }
         }
-        $obj->tmlpRegistration = $application;
+        $obj->id = $application->id;
 
         return $obj;
     }

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -117,7 +117,7 @@ class TeamApplication extends ParserDomain
                     $obj->$k = $application->$k;
                     break;
                 case 'applicationData':
-                    if ($appData != null) {
+                    if ($appData) {
                         $obj->$k = $appData->$k;
                     }
             }

--- a/src/app/Http/Controllers/ApiController.php
+++ b/src/app/Http/Controllers/ApiController.php
@@ -30,7 +30,7 @@ class ApiController extends ApiControllerBase
         "Course.update" => "Course__update",
         "Course.allForCenter" => "Course__allForCenter",
         "Course.getWeekData" => "Course__getWeekData",
-        "Course.setWeekData" => "Course__setWeekData",
+        "Course.stash" => "Course__stash",
         "GlobalReport.getRating" => "GlobalReport__getRating",
         "GlobalReport.getQuarterScoreboard" => "GlobalReport__getQuarterScoreboard",
         "GlobalReport.getWeekScoreboard" => "GlobalReport__getWeekScoreboard",
@@ -131,6 +131,7 @@ class ApiController extends ApiControllerBase
     {
         return App::make(Api\Course::class)->allForCenter(
             $this->parse($input, 'center', 'Center'),
+            $this->parse($input, 'includeInProgress', 'bool', false),
             $this->parse($input, 'reportingDate', 'date', false)
         );
     }
@@ -141,10 +142,10 @@ class ApiController extends ApiControllerBase
             $this->parse($input, 'reportingDate', 'date', false)
         );
     }
-    protected function Course__setWeekData($input)
+    protected function Course__stash($input)
     {
-        return App::make(Api\Course::class)->setWeekData(
-            $this->parse($input, 'course', 'Course'),
+        return App::make(Api\Course::class)->stash(
+            $this->parse($input, 'center', 'Center'),
             $this->parse($input, 'reportingDate', 'date'),
             $this->parse($input, 'data', 'array')
         );

--- a/src/app/Message.php
+++ b/src/app/Message.php
@@ -770,12 +770,61 @@ class Message
             ],
         ],
 
-        // '' => array(
-        //     'type' => Message::ERROR,
-        //     'format' => "",
-        //     'arguments' => array(
-        //     ),
-        // ),
+        // Team Application
+        'TEAMAPP_WD_CODE_MISSING' => [
+            'type' => Message::ERROR,
+            'format' => "Withdraw date was provided, but no reason was provided.",
+            'arguments' => [],
+        ],
+        'TEAMAPP_WD_DATE_MISSING' => [
+            'type' => Message::ERROR,
+            'format' => "Withdraw reason was provided, but no withdraw date.",
+            'arguments' => [],
+        ],
+        'TEAMAPP_APPR_MISSING_APPIN_DATE' => [
+            'type' => Message::ERROR,
+            'format' => 'Approval date provided, but App In date is missing.',
+            'arguments' => [],
+        ],
+        'TEAMAPP_APPR_MISSING_APPOUT_DATE' => [
+            'type' => Message::ERROR,
+            'format' => 'Approval date provided, but App Out date is missing.',
+            'arguments' => [],
+        ],
+        'TEAMAPP_APPIN_MISSING_APPOUT_DATE' => [
+            'type' => Message::ERROR,
+            'format' => 'App In date provided, but App Out date is missing.',
+            'arguments' => [],
+        ],
+        // TODO: rewrite the message text with a more accurate error
+        'TEAMAPP_TRAVEL_COMMENT_MISSING' => [
+            'type' => Message::ERROR,
+            'format' => 'Either travel must be complete and marked with a Y in the Travel column, or a comment with a specific promise must be provided',
+            'arguments' => [],
+        ],
+        // TODO: rewrite the message text with a more accurate error
+        'TEAMAPP_ROOM_COMMENT_MISSING' => [
+            'type' => Message::ERROR,
+            'format' => 'Either rooming must be complete and marked with a Y in the Room column, or a comment with a specific promise must be provided',
+            'arguments' => [],
+        ],
+        // TODO: rewrite the message text with a more accurate error
+        'TEAMAPP_TRAVEL_COMMENT_REVIEW' => [
+            'type' => Message::WARNING,
+            'format' => 'Travel is not booked. Make sure the comment provides a specific promise for when travel will be complete.',
+            'arguments' => [],
+        ],
+        // TODO: rewrite the message text with a more accurate error
+        'TEAMAPP_ROOM_COMMENT_REVIEW' => [
+            'type' => Message::WARNING,
+            'format' => 'Rooming is not booked. Make sure the comment provides a specific promise for when rooming will be complete.',
+            'arguments' => [],
+        ],
+        'TEAMAPP_REVIEWER_TEAM1' => [
+            'type' => Message::ERROR,
+            'format' => 'Only Team 2 can be reviewers. Please check that the team year and reviewer statuses are correct.',
+            'arguments' => [],
+        ],
     ];
 
     protected $section = '';

--- a/src/app/Traits/GeneratesApiMessages.php
+++ b/src/app/Traits/GeneratesApiMessages.php
@@ -1,0 +1,77 @@
+<?php
+namespace TmlpStats\Traits;
+
+use TmlpStats\Message;
+use TmlpStats\Settings\Setting;
+
+trait GeneratesApiMessages
+{
+    /**
+     * Override message class for specific message set
+     * @var string
+     */
+    protected $messageClass = Message::class;
+
+    /**
+     * Get messages
+     *
+     * This is required because we can't know if the has already included a $messages member.
+     *
+     * @return array Array of messages
+     */
+    public function getMessages()
+    {
+        if (!isset($this->messages)) {
+            $this->messages = [];
+        }
+
+        return $this->messages;
+    }
+
+    /**
+     * Get sheet ID
+     *
+     * This is required because we can't know if the has already included a $sheetId member.
+     *
+     * @return string Sheet identifier
+     */
+    public function getSheetId()
+    {
+        if (!isset($this->sheetId)) {
+            $this->sheetId = 'unknown';
+        }
+
+        return $this->sheetId;
+    }
+
+    /**
+     * Create and add message to local message store
+     *
+     * @param string $messageId Message identifier
+     * @param mixed  Arbitrary number of additional arguments
+     */
+    protected function addMessage($messageId)
+    {
+        $class = $this->messageClass;
+        $message = $class::create($this->sheetId);
+        $offset = null;
+
+        $arguments = func_get_args();
+        if (method_exists($this, 'getOffset') && isset($this->data)) {
+            $offset = $this->getOffset($this->data);
+        }
+        array_splice($arguments, 1, 0, $offset);
+
+        $this->messages[] = $this->callMessageAdd($message, $arguments);
+    }
+
+    /**
+     * Calls addMessage on message class
+     *
+     * @codeCoverageIgnore
+     */
+    protected function callMessageAdd($message, $arguments)
+    {
+        return call_user_func_array([$message, 'addMessage'], $arguments);
+    }
+}

--- a/src/app/Validate/ApiValidationManager.php
+++ b/src/app/Validate/ApiValidationManager.php
@@ -1,0 +1,90 @@
+<?php
+namespace TmlpStats\Validate;
+
+class ApiValidationManager
+{
+    protected $statsReport = null;
+    protected $messages = [];
+
+    public function __construct($statsReport)
+    {
+        $this->statsReport = $statsReport;
+    }
+
+    /**
+     * Run the full suite of validators on $data
+     *
+     * Object should be grouped by object type. e.g.
+     * $data = [
+     *     'teamApplication' => [...Array of team application domain objects],
+     *     'teamMember'      => [...Array of team member domain objects],
+     *     'scoreboard'      => [...Array of scoreboard objects],
+     *     'course'          => [...Array of course domain objects],
+     * ];
+     *
+     * @param  array  $data  Array of objects to validate
+     * @return boolen
+     */
+    public function run($data)
+    {
+        $isValid = true;
+
+        foreach ($data as $type => $list) {
+            $apiType = 'api' . ucfirst($type);
+            if (!$this->processDataList($apiType, $list)) {
+                $isValid = false;
+            }
+        }
+
+        $validator = ValidatorFactory::build($this->statsReport, 'apiCenterGames');
+        if (!$validator->run($data)) {
+            $isValid = false;
+        }
+        $this->mergeMessages($validator->getMessages());
+
+        return $isValid;
+    }
+
+    public function runOne($data, $id = null)
+    {
+        $isValid = true;
+
+        $type = class_basename(get_class($data));
+        $apiType = 'api' . ucfirst($type);
+
+        $validator = ValidatorFactory::build($this->statsReport, $apiType);
+        $validator->setOffset($id);
+        if (!$validator->run($data)) {
+            $isValid = false;
+        }
+        $this->mergeMessages($validator->getMessages());
+
+        return $isValid;
+    }
+
+    protected function processDataList($type, $list)
+    {
+        $isValid = true;
+        foreach ($list as $id => $dataObj) {
+            $validator = ValidatorFactory::build($this->statsReport, $type);
+            $validator->setOffset($id);
+            if (!$validator->run($dataObj)) {
+                $isValid = false;
+            }
+            // TODO pair messages with object so we can match them up later when displaying to user
+            $this->mergeMessages($validator->getMessages());
+        }
+
+        return $isValid;
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    protected function mergeMessages($messages)
+    {
+        $this->messages = array_merge($this->messages, $messages);
+    }
+}

--- a/src/app/Validate/Objects/ApiCourseValidator.php
+++ b/src/app/Validate/Objects/ApiCourseValidator.php
@@ -1,0 +1,9 @@
+<?php
+namespace TmlpStats\Validate\Objects;
+
+use TmlpStats\Traits;
+
+class ApiCourseValidator extends CommCourseInfoValidator
+{
+    use Traits\GeneratesApiMessages;
+}

--- a/src/app/Validate/Objects/ApiScoreboardValidator.php
+++ b/src/app/Validate/Objects/ApiScoreboardValidator.php
@@ -1,0 +1,9 @@
+<?php
+namespace TmlpStats\Validate\Objects;
+
+use TmlpStats\Traits;
+
+class ApiScoreboardValidator extends CenterStatsValidator
+{
+    use Traits\GeneratesApiMessages;
+}

--- a/src/app/Validate/Objects/ApiTeamApplicationValidator.php
+++ b/src/app/Validate/Objects/ApiTeamApplicationValidator.php
@@ -1,0 +1,269 @@
+<?php
+namespace TmlpStats\Validate\Objects;
+
+use Respect\Validation\Validator as v;
+use TmlpStats\Models;
+use TmlpStats\Traits;
+
+// TODO: Review messages to make sure they are as accurate as possible
+
+class ApiTeamApplicationValidator extends TmlpRegistrationValidator
+{
+    use Traits\GeneratesApiMessages, Traits\ValidatesTravelWithConfig;
+
+    protected $startingNextQuarter = null;
+
+    protected function populateValidators($data)
+    {
+        $idValidator         = v::numeric()->positive();
+        $nameValidator       = v::stringType()->notEmpty();
+        $dateValidator       = v::date('Y-m-d');
+        $dateOrNullValidator = v::optional($dateValidator);
+        $boolOrNullValidator = v::optional(v::boolType());
+
+        $this->dataValidators['firstName']  = $nameValidator;
+        $this->dataValidators['lastName']   = $nameValidator;
+        $this->dataValidators['email']      = v::optional(v::email());
+        $this->dataValidators['phone']      = v::optional(v::phone());
+        $this->dataValidators['teamYear']   = v::numeric()->between(1, 2, true);
+        $this->dataValidators['regDate']    = $dateValidator;
+        $this->dataValidators['appOutDate'] = $dateOrNullValidator;
+        $this->dataValidators['appInDate']  = $dateOrNullValidator;
+        $this->dataValidators['apprDate']   = $dateOrNullValidator;
+        $this->dataValidators['wdDate']     = $dateOrNullValidator;
+        $this->dataValidators['travel']     = $boolOrNullValidator;
+        $this->dataValidators['room']       = $boolOrNullValidator;
+        $this->dataValidators['isReviewer'] = $boolOrNullValidator;
+        $this->dataValidators['incomingQuarterId']     = $idValidator;
+        $this->dataValidators['withdrawCodeId']        = v::optional($idValidator);
+        $this->dataValidators['committedTeamMemberId'] = v::optional($idValidator);
+    }
+
+    protected function validate($data)
+    {
+        if (!$this->validateApprovalProcess($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateDates($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateTravel($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateReviewer($data)) {
+            $this->isValid = false;
+        }
+
+        return $this->isValid;
+    }
+
+    public function validateApprovalProcess($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->withdrawCodeId) || !is_null($data->wdDate)) {
+            $col = 'wd';
+            if (is_null($data->withdrawCodeId)) {
+                $this->addMessage('TEAMAPP_WD_CODE_MISSING');
+                $isValid = false;
+            }
+            if (is_null($data->wdDate)) {
+                $this->addMessage('TEAMAPP_WD_DATE_MISSING');
+                $isValid = false;
+            }
+        } else if (!is_null($data->apprDate)) {
+            $col = 'appr';
+            if (is_null($data->appInDate)) {
+                $this->addMessage('TEAMAPP_APPR_MISSING_APPIN_DATE');
+                $isValid = false;
+            }
+            if (is_null($data->appOutDate)) {
+                $this->addMessage('TEAMAPP_APPR_MISSING_APPOUT_DATE');
+                $isValid = false;
+            }
+        } else if (!is_null($data->appInDate)) {
+            $col = 'in';
+            if (is_null($data->appOutDate)) {
+                $this->addMessage('TEAMAPP_APPIN_MISSING_APPOUT_DATE');
+                $isValid = false;
+            }
+        }
+
+        if (is_null($data->committedTeamMemberId) && is_null($data->withdrawCodeId)) {
+            $this->addMessage('TMLPREG_NO_COMMITTED_TEAM_MEMBER');
+            $isValid = false;
+        }
+
+        return $isValid;
+    }
+
+    public function validateDates($data)
+    {
+        $isValid = true;
+
+        // Make sure dates for each step make sense
+        if ($data->wdDate) {
+            if ($data->regDate && $data->wdDate->lt($data->regDate)) {
+                $this->addMessage('TMLPREG_WD_DATE_BEFORE_REG_DATE');
+                $isValid = false;
+            }
+            if ($data->apprDate && $data->wdDate->lt($data->apprDate)) {
+                $this->addMessage('TMLPREG_WD_DATE_BEFORE_APPR_DATE');
+                $isValid = false;
+            }
+            if ($data->appInDate && $data->wdDate->lt($data->appInDate)) {
+                $this->addMessage('TMLPREG_WD_DATE_BEFORE_APPIN_DATE');
+                $isValid = false;
+            }
+            if ($data->appOutDate && $data->wdDate->lt($data->appOutDate)) {
+                $this->addMessage('TMLPREG_WD_DATE_BEFORE_APPOUT_DATE');
+                $isValid = false;
+            }
+        }
+        if ($data->apprDate) {
+            if ($data->regDate && $data->apprDate->lt($data->regDate)) {
+                $this->addMessage('TMLPREG_APPR_DATE_BEFORE_REG_DATE');
+                $isValid = false;
+            }
+            if ($data->appInDate && $data->apprDate->lt($data->appInDate)) {
+                $this->addMessage('TMLPREG_APPR_DATE_BEFORE_APPIN_DATE');
+                $isValid = false;
+            }
+            if ($data->appOutDate && $data->apprDate->lt($data->appOutDate)) {
+                $this->addMessage('TMLPREG_APPR_DATE_BEFORE_APPOUT_DATE');
+                $isValid = false;
+            }
+        }
+        if ($data->appInDate) {
+            if ($data->regDate && $data->appInDate->lt($data->regDate)) {
+                $this->addMessage('TMLPREG_APPIN_DATE_BEFORE_REG_DATE');
+                $isValid = false;
+            }
+            if ($data->appOutDate && $data->appInDate->lt($data->appOutDate)) {
+                $this->addMessage('TMLPREG_APPIN_DATE_BEFORE_APPOUT_DATE');
+                $isValid = false;
+            }
+        }
+        if ($data->appOutDate) {
+            if ($data->regDate && $data->appOutDate->lt($data->regDate)) {
+                $this->addMessage('TMLPREG_APPOUT_DATE_BEFORE_REG_DATE');
+                $isValid = false;
+            }
+        }
+
+        $maxAppOutDays      = static::MAX_DAYS_TO_SEND_APPLICATION_OUT;
+        $maxApplicationDays = static::MAX_DAYS_TO_APPROVE_APPLICATION;
+        $reportingDate = $this->statsReport->reportingDate;
+
+        if (is_null($data->wdDate)) {
+            // Make sure steps are taken in timely manner
+            if (is_null($data->appOutDate)) {
+                if ($data->regDate
+                    && $data->regDate->lt($reportingDate)
+                    && $data->regDate->diffInDays($reportingDate) > $maxAppOutDays
+                ) {
+                    $this->addMessage('TMLPREG_APPOUT_LATE', $maxAppOutDays);
+                }
+            } else if (is_null($data->appInDate)) {
+                if ($data->appOutDate
+                    && $data->appOutDate->lt($reportingDate)
+                    && $data->appOutDate->diffInDays($reportingDate) > $maxApplicationDays
+                ) {
+                    $this->addMessage('TMLPREG_APPIN_LATE', $maxApplicationDays);
+                }
+            } else if (is_null($data->apprDate)) {
+                if ($data->appInDate
+                    && $data->appInDate->lt($reportingDate)
+                    && $data->appInDate->diffInDays($reportingDate) > $maxApplicationDays
+                ) {
+                    $this->addMessage('TMLPREG_APPR_LATE', $maxApplicationDays);
+                }
+            }
+        }
+
+        // Make sure dates are in the past
+        if (!is_null($data->regDate) && $reportingDate->lt($data->regDate)) {
+            $this->addMessage('TMLPREG_REG_DATE_IN_FUTURE');
+            $isValid = false;
+        }
+        if (!is_null($data->wdDate) && $reportingDate->lt($data->wdDate)) {
+            $this->addMessage('TMLPREG_WD_DATE_IN_FUTURE');
+            $isValid = false;
+        }
+        if (!is_null($data->apprDate) && $reportingDate->lt($data->apprDate)) {
+            $this->addMessage('TMLPREG_APPR_DATE_IN_FUTURE');
+            $isValid = false;
+        }
+        if (!is_null($data->appInDate) && $reportingDate->lt($data->appInDate)) {
+            $this->addMessage('TMLPREG_APPIN_DATE_IN_FUTURE');
+            $isValid = false;
+        }
+        if (!is_null($data->appOutDate) && $reportingDate->lt($data->appOutDate)) {
+            $this->addMessage('TMLPREG_APPOUT_DATE_IN_FUTURE');
+            $isValid = false;
+        }
+
+        return $isValid;
+    }
+
+    // TODO: Revisit this after we decide on the travel flow
+    public function validateTravel($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->withdrawCodeId) || !$this->isStartingNextQuarter($data)) {
+            return $isValid; // Not required if withdrawn or future registration
+        }
+
+        // Travel and Rooming must be reported starting after the configured date
+        if ($this->isTimeToCheckTravel()) {
+            if (is_null($data->travel)) {
+                // Error if no comment provided, warning to look at it otherwise
+                if (is_null($data->comment)) {
+                    $this->addMessage('TEAMAPP_TRAVEL_COMMENT_MISSING');
+                    $isValid = false;
+                } else {
+                    $this->addMessage('TEAMAPP_TRAVEL_COMMENT_REVIEW');
+                }
+            }
+            if (is_null($data->room)) {
+                // Error if no comment provided, warning to look at it otherwise
+                if (is_null($data->comment)) {
+                    $this->addMessage('TEAMAPP_ROOM_COMMENT_MISSING');
+                    $isValid = false;
+                } else {
+                    $this->addMessage('TEAMAPP_ROOM_COMMENT_REVIEW');
+                }
+            }
+        }
+
+        return $isValid;
+    }
+
+    public function validateReviewer($data)
+    {
+        $isValid = true;
+
+        if ($data->isReviewer && $data->teamYear !== 2) {
+            $this->addMessage('TEAMAPP_REVIEWER_TEAM1');
+            $isValid = false;
+        }
+
+        return $isValid;
+    }
+
+    public function isStartingNextQuarter($data)
+    {
+        if ($this->startingNextQuarter !== null) {
+            return $this->startingNextQuarter;
+        }
+
+        $nextQuarter = $this->statsReport->quarter->getNextQuarter();
+
+        if (!$nextQuarter) {
+            return false;
+        }
+
+        return $this->startingNextQuarter = ($nextQuarter->id === $data->incomingQuarterId);
+    }
+}

--- a/src/app/Validate/Objects/ApiTeamMemberValidator.php
+++ b/src/app/Validate/Objects/ApiTeamMemberValidator.php
@@ -1,0 +1,201 @@
+<?php
+namespace TmlpStats\Validate\Objects;
+
+use Respect\Validation\Validator as v;
+use TmlpStats\Traits;
+
+class ApiTeamMemberValidator extends ClassListValidator
+{
+    use Traits\GeneratesApiMessages, Traits\ValidatesTravelWithConfig;
+
+    protected function populateValidators($data)
+    {
+        $idValidator         = v::numeric()->positive();
+        $nameValidator       = v::stringType()->notEmpty();
+        $boolValidator       = v::boolType();
+        $boolOrNullValidator = v::optional($boolValidator);
+        $teamYearValidator   = v::numeric()->between(1, 2, true);
+
+        $this->dataValidators['firstName']  = $nameValidator;
+        $this->dataValidators['lastName']   = $nameValidator;
+        $this->dataValidators['teamYear']   = $teamYearValidator;
+        $this->dataValidators['atWeekend']  = $boolValidator;
+        $this->dataValidators['isReviewer'] = $boolOrNullValidator;
+        $this->dataValidators['xferOut']    = $boolOrNullValidator;
+        $this->dataValidators['xferIn']     = $boolOrNullValidator;
+        $this->dataValidators['ctw']        = $boolOrNullValidator;
+        $this->dataValidators['rereg']      = $boolOrNullValidator;
+        $this->dataValidators['excep']      = $boolOrNullValidator;
+        $this->dataValidators['travel']     = $boolOrNullValidator;
+        $this->dataValidators['room']       = $boolOrNullValidator;
+        $this->dataValidators['gitw']       = $boolOrNullValidator;
+        $this->dataValidators['tdo']        = $boolOrNullValidator;
+        $this->dataValidators['withdrawCodeId'] = v::optional($idValidator);
+    }
+
+    protected function validate($data)
+    {
+        if (!$this->validateGitw($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateTdo($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateTeamYear($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateTransfer($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateWithdraw($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateTravel($data)) {
+            $this->isValid = false;
+        }
+
+        return $this->isValid;
+    }
+
+    public function validateGitw($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->xferOut) || !is_null($data->withdrawCodeId)) {
+            if (!is_null($data->gitw)) {
+                $this->addMessage('CLASSLIST_GITW_LEAVE_BLANK');
+                $isValid = false;
+            }
+        } else {
+            if (is_null($data->gitw)) {
+                $this->addMessage('CLASSLIST_GITW_MISSING');
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
+
+    public function validateTdo($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->xferOut) || !is_null($data->withdrawCodeId)) {
+            if (!is_null($data->tdo)) {
+                $this->addMessage('CLASSLIST_TDO_LEAVE_BLANK');
+                $isValid = false;
+            }
+        } else {
+            if (is_null($data->tdo)) {
+                $this->addMessage('CLASSLIST_TDO_MISSING');
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
+
+    public function validateTeamYear($data)
+    {
+        $isValid = true;
+
+        if (is_null($data->atWeekend) && is_null($data->xferIn) && is_null($data->rereg)) {
+            $this->addMessage('CLASSLIST_WKND_MISSING', $data->teamYear);
+            $isValid = false;
+        } else {
+            $cellCount = 0;
+            if (!is_null($data->atWeekend)) {
+                $cellCount++;
+            }
+            if (!is_null($data->xferIn)) {
+                $cellCount++;
+            }
+            if (!is_null($data->rereg)) {
+                $cellCount++;
+            }
+
+            if ($cellCount !== 1) {
+                $this->addMessage('CLASSLIST_WKND_XIN_REREG_ONLY_ONE', $data->teamYear);
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
+
+    public function validateTransfer($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->xferIn) || !is_null($data->xferOut)) {
+
+            // TODO: We probably don't need to show this every week. We need a better way to alert something for
+            //       the first week.
+            // Always display this message.
+            $this->addMessage('CLASSLIST_XFER_CHECK_WITH_OTHER_CENTER');
+
+            if (is_null($data->comment)) {
+                $this->addMessage('CLASSLIST_XFER_COMMENT_MISSING');
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
+
+    public function validateWithdraw($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->withdrawCodeId)) {
+            if (!is_null($data->ctw)) {
+                $this->addMessage('CLASSLIST_WD_CTW_ONLY_ONE');
+                $isValid = false;
+            }
+            if (is_null($data->comment)) {
+                $this->addMessage('CLASSLIST_WD_COMMENT_MISSING');
+                $isValid = false;
+            }
+        } else if (!is_null($data->ctw)) {
+            if (is_null($data->comment)) {
+                $this->addMessage('CLASSLIST_CTW_COMMENT_MISSING');
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
+
+    public function validateTravel($data)
+    {
+        $isValid = true;
+
+        if (!is_null($data->withdrawCodeId) || !is_null($data->xferOut)) {
+            return $isValid; // Not required if withdrawn
+        }
+
+        // Travel and Rooming must be reported starting after the configured date
+        if ($this->isTimeToCheckTravel()) {
+            if (is_null($data->travel)) {
+                // Error if no comment provided, warning to look at it otherwise
+                if (is_null($data->comment)) {
+                    $this->addMessage('CLASSLIST_TRAVEL_COMMENT_MISSING');
+                    $isValid = false;
+                } else {
+                    $this->addMessage('CLASSLIST_TRAVEL_COMMENT_REVIEW');
+                }
+            }
+            if (is_null($data->room)) {
+                // Error if no comment provided, warning to look at it otherwise
+                if (is_null($data->comment)) {
+                    $this->addMessage('CLASSLIST_ROOM_COMMENT_MISSING');
+                    $isValid = false;
+                } else {
+                    $this->addMessage('CLASSLIST_ROOM_COMMENT_REVIEW');
+                }
+            }
+        }
+
+        return $isValid;
+    }
+}

--- a/src/app/Validate/Relationships/ApiCenterGamesValidator.php
+++ b/src/app/Validate/Relationships/ApiCenterGamesValidator.php
@@ -1,0 +1,120 @@
+<?php
+namespace TmlpStats\Validate\Relationships;
+
+use TmlpStats\Traits;
+
+class ApiCenterGamesValidator extends CenterGamesValidator
+{
+    use Traits\GeneratesApiMessages;
+
+    protected function validate($data)
+    {
+        // GITW and TDO
+        $activeMemberCount = 0;
+        $effectiveCount    = 0;
+
+        foreach ($data['teamMember'] as $member) {
+            if ($member->withdrawCodeId || $member->xferOut) {
+                continue;
+            }
+
+            $activeMemberCount++;
+            if ($member->gitw) {
+                $effectiveCount++;
+            }
+        }
+
+        $gitwGame = $activeMemberCount ? round(($effectiveCount / $activeMemberCount) * 100) : 0;
+
+        // CAP & CPC Game
+        $capCurrentStandardStarts = 0;
+        $capQStartStandardStarts  = 0;
+        $cpcCurrentStandardStarts = 0;
+        $cpcQStartStandardStarts  = 0;
+
+        foreach ($data['course'] as $course) {
+            if ($course->type == 'CAP') {
+                $capCurrentStandardStarts += $course->currentStandardStarts;
+                $capQStartStandardStarts += $course->quarterStartStandardStarts;
+            } else if ($course->type == 'CPC') {
+                $cpcCurrentStandardStarts += $course->currentStandardStarts;
+                $cpcQStartStandardStarts += $course->quarterStartStandardStarts;
+            }
+        }
+
+        $capGame = $capCurrentStandardStarts - $capQStartStandardStarts;
+        $cpcGame = $cpcCurrentStandardStarts - $cpcQStartStandardStarts;
+
+        // T1x and T2x Games
+        $t1CurrentApproved = 0;
+        $t2CurrentApproved = 0;
+
+        foreach ($data['teamApplication'] as $registration) {
+            if (!$registration->apprDate) {
+                continue;
+            }
+
+            if ($registration->teamYear == 1) {
+                $t1CurrentApproved++;
+            } else {
+                $t2CurrentApproved++;
+            }
+        }
+
+        $thisWeekActual = null;
+
+        // TODO: Fix this to work properly with the new Scoreboard
+        foreach ($data['scoreboard'] as $week) {
+            if ($week->type == 'actual' && $week->reportingDate->eq($this->reportingDate)) {
+                $thisWeekActual = $week;
+                break;
+            }
+        }
+
+        $t1QStartApproved = 0;
+        $t2QStartApproved = 0;
+
+        // TODO: Find a way to pull this info from database
+
+        // foreach ($data['tmlpCourseInfo'] as $game) {
+        //     if (strpos($game->type, 'T1') !== false) {
+        //         $t1QStartApproved += $game->quarterStartApproved;
+        //     } else {
+        //         $t2QStartApproved += $game->quarterStartApproved;
+        //     }
+        // }
+
+        $t1xGame = $t1CurrentApproved - $t1QStartApproved;
+        $t2xGame = $t2CurrentApproved - $t2QStartApproved;
+
+        // Make sure they match
+        if ($thisWeekActual) {
+            if ($thisWeekActual->cap != $capGame) {
+                $this->addMessage('IMPORTDOC_CAP_ACTUAL_INCORRECT', $thisWeekActual->cap, $capGame);
+                $this->isValid = false;
+            }
+
+            if ($thisWeekActual->cpc != $cpcGame) {
+                $this->addMessage('IMPORTDOC_CPC_ACTUAL_INCORRECT', $thisWeekActual->cpc, $cpcGame);
+                $this->isValid = false;
+            }
+
+            if ($thisWeekActual->t1x != $t1xGame) {
+                $this->addMessage('IMPORTDOC_T1X_ACTUAL_INCORRECT', $thisWeekActual->t1x, $t1xGame);
+                $this->isValid = false;
+            }
+
+            if ($thisWeekActual->t2x != $t2xGame) {
+                $this->addMessage('IMPORTDOC_T2X_ACTUAL_INCORRECT', $thisWeekActual->t2x, $t2xGame);
+                $this->isValid = false;
+            }
+
+            if ($thisWeekActual->gitw != $gitwGame) {
+                $this->addMessage('IMPORTDOC_GITW_ACTUAL_INCORRECT', $thisWeekActual->gitw, $gitwGame);
+                $this->isValid = false;
+            }
+        }
+
+        return $this->isValid;
+    }
+}

--- a/src/app/Validate/ValidatorAbstract.php
+++ b/src/app/Validate/ValidatorAbstract.php
@@ -11,6 +11,7 @@ abstract class ValidatorAbstract
     protected $data = null;
     protected $supplementalData = null;
     protected $statsReport = null;
+    protected $offset = null;
 
     protected $messages = [];
 
@@ -73,7 +74,16 @@ abstract class ValidatorAbstract
 
     protected function getOffset($data)
     {
+        if ($this->offset !== null) {
+            return $this->offset;
+        }
+
         return isset($data->offset) ? $data->offset : null;
+    }
+
+    public function setOffset($offset)
+    {
+        $this->offset = $offset;
     }
 
     protected function addMessage($messageId)

--- a/src/app/Validate/ValidatorFactory.php
+++ b/src/app/Validate/ValidatorFactory.php
@@ -3,7 +3,7 @@ namespace TmlpStats\Validate;
 
 class ValidatorFactory
 {
-    public static function build(&$statsReport, $type = null)
+    public static function build($statsReport, $type = null)
     {
         if ($type === null) {
             $type = 'null';
@@ -17,6 +17,10 @@ class ValidatorFactory
             case 'commCourseInfo':
             case 'tmlpCourseInfo':
             case 'statsReport':
+            case 'apiCourse':
+            case 'apiScoreboard':
+            case 'apiTeamApplication':
+            case 'apiTeamMember':
                 $class = '\\TmlpStats\\Validate\\Objects\\' . ucfirst($type) . 'Validator';
                 break;
             case 'committedTeamMember':
@@ -25,6 +29,7 @@ class ValidatorFactory
             case 'duplicateTmlpRegistration':
             case 'teamExpansion':
             case 'centerGames':
+            case 'apiCenterGames':
                 $class = '\\TmlpStats\\Validate\\Relationships\\' . ucfirst($type) . 'Validator';
                 break;
             case 'null':

--- a/src/config/reports.yml
+++ b/src/config/reports.yml
@@ -117,6 +117,9 @@ api:
         params:
           - name: center
             type: Center
+          - name: includeInProgress
+            type: bool
+            required: false
           - name: reportingDate
             type: date
             required: false
@@ -128,11 +131,11 @@ api:
           - name: reportingDate
             type: date
             required: false
-      setWeekData:
-        desc: Set the weekly data for an course
+      stash:
+        desc: Stash combined data for an course
         params:
-          - name: course
-            type: Course
+          - name: center
+            type: Center
           - name: reportingDate
             type: date
           - name: data

--- a/src/public/js/api.js
+++ b/src/public/js/api.js
@@ -132,6 +132,7 @@ Api.Course = {
     List courses by center
     Parameters:
       center: Center
+      includeInProgress: bool
       reportingDate: date
     */
     allForCenter: function(params, callback, errback) {
@@ -149,14 +150,14 @@ Api.Course = {
     },
 
     /*
-    Set the weekly data for an course
+    Stash combined data for an course
     Parameters:
-      course: Course
+      center: Center
       reportingDate: date
       data: array
     */
-    setWeekData: function(params, callback, errback) {
-        return apiCall('Course.setWeekData', params, (callback || null), (errback || null));
+    stash: function(params, callback, errback) {
+        return apiCall('Course.stash', params, (callback || null), (errback || null));
     }
 };
 Api.GlobalReport = {

--- a/src/resources/assets/js/submission/SubmissionFlow.jsx
+++ b/src/resources/assets/js/submission/SubmissionFlow.jsx
@@ -12,8 +12,8 @@ export default function SubmissionFlow() {
             <Route path="applications/add" component={Pages.ApplicationsAdd} />
             <Route path="classlist" component={Pages.ClassList} />
             <Route path="courses" component={Pages.CoursesIndex} />
-            <Route path="courses/add" component={Pages.CoursesAdd} />
             <Route path="courses/edit/:courseId" component={Pages.CoursesEdit} />
+            <Route path="courses/add" component={Pages.CoursesAdd} />
             <Route path="review" component={Pages.Review} />
         </Route>
     )

--- a/src/resources/assets/js/submission/applications/AppStatus.jsx
+++ b/src/resources/assets/js/submission/applications/AppStatus.jsx
@@ -98,7 +98,7 @@ export default class AppStatus extends React.Component {
                         <input type="text" className="form-control" />
                     </Field>
                     <br />
-                    <SimpleSelect model={model+'.withdrawCodeId'} keyProp="id" labelProp="display" items={this.props.lookups.withdraw_codes} />
+                    <SimpleSelect model={model+'.withdrawCode'} keyProp="id" labelProp="display" items={this.props.lookups.withdraw_codes} />
                 </div>
             </div>
         )

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -97,7 +97,7 @@ class _EditCreate extends ApplicationsBase {
                         <label className="col-sm-2">Committed Team Member</label>
                         <div className="col-sm-10">
                             <SimpleSelect
-                                    model={modelKey+'.committedTeamMemberId'} items={this.props.lookups.team_members}
+                                    model={modelKey+'.committedTeamMember'} items={this.props.lookups.team_members}
                                     keyProp="teamMemberId" getLabel={getLabelTeamMember} emptyChoice="Choose One" />
                         </div>
                     </div>
@@ -122,7 +122,7 @@ class _EditCreate extends ApplicationsBase {
     saveApp(data) {
         this.props.dispatch(saveApplication(this.props.params.centerId, this.reportingDateString(), data)).done((result) => {
             if (result.success && result.storedId) {
-                data = Object.assign({}, data, {tmlpRegistrationId: result.storedId})
+                data = Object.assign({}, data, {tmlpRegistration: result.storedId})
                 this.props.dispatch(appsCollection.replaceItem(data))
             }
             this.props.router.push(this.baseUri() + '/applications')
@@ -134,7 +134,7 @@ class ApplicationsEditView extends _EditCreate {
     componentDidMount() {
         super.setupApplications().then(() => {
             var appId = this.props.params.appId
-            if (!this.props.currentApp || this.props.currentApp.tmlpRegistrationId != appId) {
+            if (!this.props.currentApp || this.props.currentApp.tmlpRegistration != appId) {
                 this.props.dispatch(chooseApplication(appId, this.getAppById(appId)))
             }
         })
@@ -147,7 +147,7 @@ class ApplicationsEditView extends _EditCreate {
     render() {
         const appId = this.props.params.appId
 
-        if (!this.props.loading.loaded || !this.props.currentApp || this.props.currentApp.tmlpRegistrationId != appId) {
+        if (!this.props.loading.loaded || !this.props.currentApp || this.props.currentApp.tmlpRegistration != appId) {
             return <div>{this.props.loading.state}...</div>
         }
         return super.render()

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -33,6 +33,7 @@ class ApplicationsBase extends SubmissionBase {
 
 class ApplicationsIndexView extends ApplicationsBase {
     render() {
+        console.log(this.props.loading)
         if (!this.props.loading.loaded) {
             return this.renderBasicLoading()
         }

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -122,7 +122,7 @@ class _EditCreate extends ApplicationsBase {
     saveApp(data) {
         this.props.dispatch(saveApplication(this.props.params.centerId, this.reportingDateString(), data)).done((result) => {
             if (result.success && result.storedId) {
-                data = Object.assign({}, data, {tmlpRegistration: result.storedId})
+                data = Object.assign({}, data, {id: result.storedId})
                 this.props.dispatch(appsCollection.replaceItem(data))
             }
             this.props.router.push(this.baseUri() + '/applications')
@@ -134,7 +134,7 @@ class ApplicationsEditView extends _EditCreate {
     componentDidMount() {
         super.setupApplications().then(() => {
             var appId = this.props.params.appId
-            if (!this.props.currentApp || this.props.currentApp.tmlpRegistration != appId) {
+            if (!this.props.currentApp || this.props.currentApp.id != appId) {
                 this.props.dispatch(chooseApplication(appId, this.getAppById(appId)))
             }
         })
@@ -147,7 +147,7 @@ class ApplicationsEditView extends _EditCreate {
     render() {
         const appId = this.props.params.appId
 
-        if (!this.props.loading.loaded || !this.props.currentApp || this.props.currentApp.tmlpRegistration != appId) {
+        if (!this.props.loading.loaded || !this.props.currentApp || this.props.currentApp.id != appId) {
             return <div>{this.props.loading.state}...</div>
         }
         return super.render()

--- a/src/resources/assets/js/submission/applications/data.js
+++ b/src/resources/assets/js/submission/applications/data.js
@@ -16,7 +16,7 @@ export const appsSorts = [
 
 export const appsCollection = new SortableCollection({
     name: 'submission.applications',
-    key_prop: 'tmlpRegistration',
+    key_prop: 'id',
     sort_by: 'teamYear_first_last',
     sorts: appsSorts
 })

--- a/src/resources/assets/js/submission/applications/data.js
+++ b/src/resources/assets/js/submission/applications/data.js
@@ -16,7 +16,7 @@ export const appsSorts = [
 
 export const appsCollection = new SortableCollection({
     name: 'submission.applications',
-    key_prop: 'tmlpRegistrationId',
+    key_prop: 'tmlpRegistration',
     sort_by: 'teamYear_first_last',
     sorts: appsSorts
 })

--- a/src/resources/assets/js/submission/courses/CourseStatus.jsx
+++ b/src/resources/assets/js/submission/courses/CourseStatus.jsx
@@ -1,0 +1,123 @@
+import { React } from '../base_components'
+import { Field, SimpleSelect } from '../../reusable/form_utils'
+import { setCourseStatus } from './actions'
+
+const STATUS_UNKNOWN=0,
+    STATUS_REG=1,
+    STATUS_OUT=2,
+    STATUS_IN=3,
+    STATUS_APPR=4,
+    STATUS_WD=5
+
+// Since the status is not stored currently inside the model, we will just infer it from the existing properties
+export function inferStatus(course) {
+    if (course.courseStatus) {
+        return course.courseStatus
+    }
+    if (course.wdDate) {
+        return STATUS_WD
+    }
+    if (course.courserDate) {
+        return STATUS_APPR
+    }
+    if (course.courseInDate) {
+        return STATUS_IN
+    }
+    if (course.courseOutDate) {
+        return STATUS_OUT
+    }
+    if (course.regDate) {
+        return STATUS_REG
+    }
+    return STATUS_UNKNOWN
+}
+
+var STATUS_BEHAVIOUR = [
+    {status: STATUS_REG, key: 'regDate', title: 'Registered'},
+    {status: STATUS_OUT, key: 'courseOutDate', title: 'Course Out'},
+    {status: STATUS_IN, key: 'courseInDate', title: 'Course In'},
+    {status: STATUS_APPR, key: 'courserDate', title: 'Courseroved', dateTitle: 'Date Courseroved'},
+    {status: STATUS_WD, key: 'wdDate', title: 'Withdrawn', dateTitle: 'Withdraw Date', renderGroup: 'renderWithdrawn'}
+]
+
+export default class CourseStatus extends React.Component {
+    render() {
+        const { model, currentCourse, dispatch } = this.props
+        var currentStatus = inferStatus(currentCourse)
+
+        var buttons = []
+        var statuses = []
+        STATUS_BEHAVIOUR.forEach((item) => {
+            var disabled = (item.status > currentStatus)
+            var classes = 'btn'
+            if (disabled) {
+                classes += ' btn-default'
+            } else {
+                classes += ' btn-success'
+            }
+            if (item.status == currentStatus) {
+                classes += ' active'
+            }
+            let clickHandler = () => dispatch(setCourseStatus(item.status))
+            buttons.push(
+                <button key={item.key} type="button" className={classes} onClick={clickHandler}>{item.title}</button>
+            )
+            statuses.push(this[item.renderGroup || 'renderGroup']({
+                disabled: disabled,
+                dateTitle: item.dateTitle || (item.title + ' Date'),
+                item: item,
+                model: model
+            }))
+        })
+        return (
+            <div className="panel panel-default">
+                <div className="panel-body">
+                    <div className="row">
+                        <div className="col-sm-offset-1 col-sm-11">
+                            <div className="btn-group" style={{paddingBottom: '15px'}}>{buttons}</div>
+                        </div>
+                    </div>
+                    <div>
+                        {statuses}
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    renderWithdrawn({ item, model, dateTitle, disabled }) {
+        if (disabled) {
+            return <div key={item.key}></div>
+        }
+        return (
+            <div className="row" key={item.key}>
+                <label className="control-label col-sm-3">{dateTitle}</label>
+                <div className="col-sm-6">
+                    <Field model={model+'.'+item.key}>
+                        <label>Withdraw Date</label>
+                        <input type="text" className="form-control" />
+                    </Field>
+                    <br />
+                    <SimpleSelect model={model+'.withdrawCode'} keyProp="id" labelProp="display" items={this.props.lookups.withdraw_codes} />
+                </div>
+            </div>
+        )
+    }
+
+    renderGroup({ item, model, dateTitle, disabled }) {
+        var style = {}
+        if (disabled) {
+            style['visibility'] = 'hidden'
+        }
+        return (
+            <div className="form-group" key={item.key} style={style}>
+                <Field model={model+'.'+item.key}>
+                    <label className="control-label col-sm-3">{dateTitle}</label>
+                    <div className="col-sm-6">
+                        <input type="text" className="form-control" disabled={disabled} aria-describedby={'addon-courses'+item.key} />
+                    </div>
+                </Field>
+            </div>
+        )
+    }
+}

--- a/src/resources/assets/js/submission/courses/actions.js
+++ b/src/resources/assets/js/submission/courses/actions.js
@@ -1,13 +1,54 @@
 ///// ACTION CREATORS
 import { actions as formActions } from 'react-redux-form'
+import { bestErrorValue } from '../../reusable/ajax_utils'
+import { coursesCollection, coursesLoad, saveCourseLoad } from './data'
 
-export const INITIALIZE_COURSES = 'courses.initialize'
+export const loadState = coursesLoad.actionCreator()
+export const saveCourseState = saveCourseLoad.actionCreator()
 
+export function loadCourses(centerId, reportingDate) {
+    return (dispatch, _, { Api }) => {
+        dispatch(loadState('loading'))
+        return Api.Course.allForCenter({
+            center: centerId,
+            includeInProgress: true,
+            reportingDate: reportingDate
+        }).done((data) => {
+            dispatch(initializeCourses(data))
+        }).fail(() => {
+            dispatch(loadState('failed'))
+        })
+    }
+}
 
 export function initializeCourses(data) {
     // This is a redux thunk which dispatches two different actions on result
     return (dispatch) => {
-        dispatch({type: INITIALIZE_COURSES})
-        dispatch(formActions.change('submission.course.courses', data))
+        dispatch(coursesCollection.replaceCollection(data))
+        dispatch(loadState('loaded'))
     }
+}
+
+export function chooseCourse(courseId, course) {
+    return formActions.change('submission.courses.currentCourse', course)
+}
+
+export function saveCourse(center, reportingDate, data) {
+    return (dispatch, _, { Api }) => {
+        const reset = () => dispatch(saveCourseState('new'))
+
+        dispatch(saveCourseState('loading'))
+        return Api.Course.stash({
+            center, reportingDate, data
+        }).done(() => {
+            reset()
+        }).fail((xhr, textStatus) => {
+            dispatch(saveCourseState({state: 'failed', error: bestErrorValue(xhr, textStatus)}))
+            setTimeout(reset, 3000)
+        })
+    }
+}
+
+export function setCourseStatus(status) {
+    return formActions.change('submission.courses.currentCourse.courseStatus', status)
 }

--- a/src/resources/assets/js/submission/courses/data.js
+++ b/src/resources/assets/js/submission/courses/data.js
@@ -1,0 +1,30 @@
+import SortableCollection, { compositeKey } from '../../reusable/sortable_collection'
+import { LoadingMultiState } from '../../reusable/reducers'
+
+export const coursesSorts = [
+    {
+        key: 'type_startDate',
+        label: 'Default',
+        comparator: compositeKey([['type', 'string'], ['startDate', 'date']])
+    },
+    {
+        key: 'startDate_type',
+        label: 'Date, Type',
+        comparator: compositeKey([['startDate', 'date'], ['type', 'string']])
+    }
+]
+
+export const coursesCollection = new SortableCollection({
+    name: 'submission.courses',
+    key_prop: 'id',
+    sort_by: 'type_startDate',
+    sorts: coursesSorts
+})
+
+export const courseTypeMap = {
+    'CAP': 'Access to Power',
+    'CPC': 'Power to Create'
+}
+
+export const coursesLoad = new LoadingMultiState('courses/initialLoadState')
+export const saveCourseLoad = new LoadingMultiState('courses/saveCourseState')

--- a/src/resources/assets/js/submission/courses/data.js
+++ b/src/resources/assets/js/submission/courses/data.js
@@ -5,12 +5,12 @@ export const coursesSorts = [
     {
         key: 'type_startDate',
         label: 'Default',
-        comparator: compositeKey([['type', 'string'], ['startDate', 'date']])
+        comparator: compositeKey([['type', 'string'], ['startDate', 'string']])
     },
     {
         key: 'startDate_type',
         label: 'Date, Type',
-        comparator: compositeKey([['startDate', 'date'], ['type', 'string']])
+        comparator: compositeKey([['startDate', 'string'], ['type', 'string']])
     }
 ]
 

--- a/src/resources/assets/js/submission/courses/reducers.js
+++ b/src/resources/assets/js/submission/courses/reducers.js
@@ -1,20 +1,15 @@
 import { combineReducers } from 'redux'
 import { modelReducer, formReducer } from 'react-redux-form'
 
-import { INITIALIZE_COURSES } from './actions'
+import { coursesCollection, coursesLoad, saveCourseLoad } from './data'
 
-function loadedReducer(state = false, action) {
-    switch (action.type) {
-    case INITIALIZE_COURSES:
-        return true
-    }
-    return state
-}
+export const COURSES_FORM_KEY = 'submission.courses.currentCourse'
 
-export const COURSES_FORM_KEY = 'submission.course.courses'
 
 export const courseReducer = combineReducers({
-    loaded: loadedReducer,
-    courses: modelReducer(COURSES_FORM_KEY, []),
-    coursesForm: formReducer(COURSES_FORM_KEY, [])
+    loading: coursesLoad.reducer(),
+    courses: coursesCollection.reducer(),
+    currentCourse: modelReducer(COURSES_FORM_KEY, []),
+    currentCourseForm: formReducer(COURSES_FORM_KEY, []),
+    saveCourse: saveCourseLoad.reducer()
 })

--- a/src/resources/assets/js/submission/reducers.js
+++ b/src/resources/assets/js/submission/reducers.js
@@ -14,7 +14,7 @@ function scoreboardReducer(state, action) {
 const submissionReducerInternal = combineReducers({
     core: coreReducer,
     applications: applicationReducer,
-    course: courseReducer,
+    courses: courseReducer,
     scoreboard: scoreboardReducer
 })
 

--- a/src/tests/TestAbstract.php
+++ b/src/tests/TestAbstract.php
@@ -4,7 +4,9 @@ namespace TmlpStats\Tests;
 use Artisan;
 use Carbon\Carbon;
 
-set_time_limit(600);
+if (ini_get('max_execution_time') < 600) {
+    ini_set('max_execution_time', 600);
+}
 
 class TestAbstract extends \Illuminate\Foundation\Testing\TestCase
 {

--- a/src/tests/Unit/Traits/MocksModel.php
+++ b/src/tests/Unit/Traits/MocksModel.php
@@ -1,0 +1,37 @@
+<?php
+namespace TmlpStats\Tests\Unit\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait MocksModel
+{
+    /**
+     * Get a Quarter object mock
+     *
+     * Getters are mocked for all fields provided in $data
+     *
+     * @param array $methods
+     * @param array $data
+     *
+     * @return mixed
+     */
+    protected function getModelMock($methods = [], $data = [])
+    {
+        static $idOffset = 0;
+
+        // We don't really need to mock this, but if nothing is mocked, then
+        // everthing is mocked. Thanks phpunit.
+        $defaultMethods = ['unguard'];
+
+        $methods = $this->mergeMockMethods($defaultMethods, $methods);
+
+        $model = $this->getMockBuilder(Model::class)
+            ->setMethods($methods)
+            ->getMock();
+
+        static::$idOffset++;
+        $model->id = static::$idOffset;
+
+        return $model;
+    }
+}

--- a/src/tests/Unit/Validate/Objects/ApiTeamApplicationValidatorTest.php
+++ b/src/tests/Unit/Validate/Objects/ApiTeamApplicationValidatorTest.php
@@ -1,0 +1,2091 @@
+<?php
+namespace TmlpStats\Tests\Unit\Validate\Objects;
+
+use Carbon\Carbon;
+use stdClass;
+use TmlpStats as Models;
+use TmlpStats\Api\Parsers;
+use TmlpStats\Domain;
+use TmlpStats\Tests\Unit\Traits\MocksMessages;
+use TmlpStats\Tests\Unit\Traits\MocksModel;
+use TmlpStats\Tests\Unit\Traits\MocksQuarters;
+use TmlpStats\Tests\Unit\Traits\MocksSettings;
+use TmlpStats\Validate\Objects\ApiTeamApplicationValidator;
+
+class ApiTeamApplicationValidatorTest extends ObjectsValidatorTestAbstract
+{
+    use MocksSettings, MocksMessages, MocksQuarters, MocksModel;
+
+    protected $instantiateApp = true;
+    protected $testClass = ApiTeamApplicationValidator::class;
+
+    protected $dataFields = [
+        'firstName',
+        'lastName',
+        'teamYear',
+        'regDate',
+        'appOutDate',
+        'appInDate',
+        'apprDate',
+        'wdDate',
+        'travel',
+        'room',
+        'incomingQuarterId',
+        'withdrawCodeId',
+        'committedTeamMemberId',
+    ];
+
+    protected $validateMethods = [
+        'validateApprovalProcess',
+        'validateDates',
+        'validateTravel',
+        'validateReviewer',
+    ];
+
+    public function addModelParserMock($parserClass)
+    {
+        $mock = $this->getModelMock();
+
+        $parser = $this->getMockBuilder($parserClass)
+                ->setMethods(['fetch'])
+                ->getMock();
+
+        $parser->expects($this->any())
+            ->method('fetch')
+            ->will($this->returnCallback(function ($class, $id) use ($mock) {
+                $mock->id = $id;
+                return $mock;
+            }));
+
+        $this->app->bind($parserClass, function ($app) use ($parser) {
+            return $parser;
+        });
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->addModelParserMock(Parsers\CenterParser::class);
+        $this->addModelParserMock(Parsers\QuarterParser::class);
+        $this->addModelParserMock(Parsers\WithdrawCodeParser::class);
+        $this->addModelParserMock(Parsers\TeamMemberParser::class);
+        $this->addModelParserMock(Parsers\ApplicationParser::class);
+    }
+
+    /**
+     * @dataProvider providerRun
+     */
+    public function testRun($data, $messages, $expectedResult)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $validator = $this->getObjectMock(['addMessage', 'validate']);
+
+        $i = 0;
+        $this->setupMessageMocks($validator, $messages, $i);
+
+        $validator->expects($this->at($i))
+            ->method('validate')
+            ->with($data);
+
+        $result = $validator->run($data);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerRun()
+    {
+        return [
+            // Test Required
+            [
+                [
+                    'firstName' => null,
+                    'lastName' => null,
+                    'email' => null,
+                    'center' => null,
+                    'teamYear' => null,
+                    'regDate' => null,
+                    'isReviewer' => null,
+                    'phone' => null,
+                    'tmlpRegistration' => null,
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'committedTeamMember' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => null,
+                    'comment' => null,
+                    'travel' => null,
+                    'room' => null,
+                ],
+                [
+                    ['INVALID_VALUE', 'First Name', '[empty]'],
+                    ['INVALID_VALUE', 'Last Name', '[empty]'],
+                    ['INVALID_VALUE', 'Team Year', '[empty]'],
+                    ['INVALID_VALUE', 'Reg Date', '[empty]'],
+                    ['INVALID_VALUE', 'Incoming Quarter Id', '[empty]'],
+                ],
+                false,
+            ],
+            // Test Valid (Variable 1)
+            [
+                [
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 1,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+            // Test Valid (Variable 2)
+            [
+                [
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 2,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => true,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => false,
+                    'room' => false,
+                ],
+                [],
+                true,
+            ],
+
+            // Test Invalid First Name
+            [
+                [
+                    'firstName' => '',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 1,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['INVALID_VALUE', 'First Name', '[empty]'],
+                ],
+                false,
+            ],
+            // Test Invalid Last Name
+            [
+                [
+                    'firstName' => 'Keith',
+                    'lastName' => '',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 1,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['INVALID_VALUE', 'Last Name', '[empty]'],
+                ],
+                false,
+            ],
+            // Test invalid TeamYear
+            [
+                [
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 3,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['INVALID_VALUE', 'Team Year', 3],
+                ],
+                false,
+            ],
+        ];
+    }
+
+    //
+    // validateApprovalProcess()
+    //
+
+    /**
+     * @dataProvider providerValidateApprovalProcess
+     */
+    public function testValidateApprovalProcess($data, $messages, $expectedResult)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $validator = $this->getObjectMock();
+
+        $this->setupMessageMocks($validator, $messages);
+
+        $result = $validator->validateApprovalProcess($data);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerValidateApprovalProcess()
+    {
+        return [
+            // Withdraw and no other steps complete
+            [
+                [
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-28'),
+                    'withdrawCode' => 1234,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+            // Withdraw and all steps complete
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-13'),
+                    'appInDate' => Carbon::parse('2015-01-20'),
+                    'apprDate' => Carbon::parse('2015-01-27'),
+                    'wdDate' => Carbon::parse('2015-01-28'),
+                    'withdrawCode' => 1234,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+            // Withdraw and missing wd
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-13'),
+                    'appInDate' => Carbon::parse('2015-01-20'),
+                    'apprDate' => Carbon::parse('2015-01-27'),
+                    'wdDate' => Carbon::parse('2015-01-28'),
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['TEAMAPP_WD_CODE_MISSING'],
+                ],
+                false,
+            ],
+            // Withdraw and missing date
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-13'),
+                    'appInDate' => Carbon::parse('2015-01-20'),
+                    'apprDate' => Carbon::parse('2015-01-27'),
+                    'wdDate' => null,
+                    'withdrawCode' => 1234,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['TEAMAPP_WD_DATE_MISSING'],
+                ],
+                false,
+            ],
+
+            // Approved
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => Carbon::parse('2015-01-21'),
+                    'apprDate' => Carbon::parse('2015-01-28'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+            // Approved and missing appInDate
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => null,
+                    'apprDate' => Carbon::parse('2015-01-28'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['TEAMAPP_APPR_MISSING_APPIN_DATE'],
+                ],
+                false,
+            ],
+            // Approved and missing appOutDate
+            [
+                [
+                    'appOutDate' => null,
+                    'appInDate' => Carbon::parse('2015-01-21'),
+                    'apprDate' => Carbon::parse('2015-01-28'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['TEAMAPP_APPR_MISSING_APPOUT_DATE'],
+                ],
+                false,
+            ],
+
+            // App In
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => Carbon::parse('2015-01-21'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+            // App In and missing appOutDate
+            [
+                [
+                    'appOutDate' => null,
+                    'appInDate' => Carbon::parse('2015-01-21'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['TEAMAPP_APPIN_MISSING_APPOUT_DATE'],
+                ],
+                false,
+            ],
+
+            // App Out
+            [
+                [
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+
+            // No approval steps complete
+            [
+                [
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [],
+                true,
+            ],
+            // Missing committed team member
+            [
+                [
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'teamYear' => 1,
+                    'committedTeamMember' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                [
+                    ['TMLPREG_NO_COMMITTED_TEAM_MEMBER'],
+                ],
+                false,
+            ],
+        ];
+    }
+
+    //
+    // validateDates()
+    //
+
+    /**
+     * @dataProvider providerValidateDates
+     */
+    public function testValidateDates($data, $statsReport, $messages, $expectedResult)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $validator = $this->getObjectMock([
+            'addMessage',
+        ], [$statsReport]);
+
+        $this->setupMessageMocks($validator, $messages);
+
+        $result = $validator->validateDates($data);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerValidateDates()
+    {
+        $statsReport = new stdClass;
+        $statsReport->center = new Models\Center();
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::createFromDate(2014, 11, 14)->startOfDay(),
+        ]);
+
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 1, 21);
+
+        return [
+            // Withdraw date OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-21'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // Withdraw and wdDate before regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_WD_DATE_BEFORE_REG_DATE'],
+                ],
+                false,
+            ],
+            // Withdraw and approve dates OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => Carbon::parse('2015-01-14'),
+                    'wdDate' => Carbon::parse('2015-01-21'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // Withdraw and wdDate before apprDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => Carbon::parse('2015-01-21'),
+                    'wdDate' => Carbon::parse('2015-01-14'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_WD_DATE_BEFORE_APPR_DATE'],
+                ],
+                false,
+            ],
+            // Withdraw and appIn dates OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-21'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // Withdraw and wdDate before appInDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => Carbon::parse('2015-01-21'),
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-14'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_WD_DATE_BEFORE_APPIN_DATE'],
+                ],
+                false,
+            ],
+            // Withdraw and appOut dates OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-21'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // Withdraw and wdDate before appOutDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-21'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => Carbon::parse('2015-01-14'),
+                    'withdrawCode' => 1234,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_WD_DATE_BEFORE_APPOUT_DATE'],
+                ],
+                false,
+            ],
+
+            // Approved date OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => Carbon::parse('2015-01-21'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // Approved and apprDate before regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPR_DATE_BEFORE_REG_DATE'],
+                    ['TMLPREG_APPR_DATE_BEFORE_APPIN_DATE'],
+                    ['TMLPREG_APPR_DATE_BEFORE_APPOUT_DATE'],
+                ],
+                false,
+            ],
+            // Approved and apprDate before appInDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => Carbon::parse('2015-01-13'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPR_DATE_BEFORE_APPIN_DATE'],
+                ],
+                false,
+            ],
+            // Approved and apprDate before appOutDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-08'),
+                    'apprDate' => Carbon::parse('2015-01-08'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPR_DATE_BEFORE_APPOUT_DATE'],
+                ],
+                false,
+            ],
+
+            // AppIn date OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // AppIn and appInDate before regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPIN_DATE_BEFORE_REG_DATE'],
+                ],
+                false,
+            ],
+            // AppIn and appInDate before appOutDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => Carbon::parse('2015-01-08'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPIN_DATE_BEFORE_APPOUT_DATE'],
+                ],
+                false,
+            ],
+
+            // AppOut date OK
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-09'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // AppOut and appOutDate before regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPOUT_DATE_BEFORE_REG_DATE'],
+                ],
+                false,
+            ],
+
+            // AppOut within 2 days of regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-01-15'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // AppOut not within 2 days of regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPOUT_LATE', ApiTeamApplicationValidator::MAX_DAYS_TO_SEND_APPLICATION_OUT],
+                ],
+                true,
+            ],
+            // AppIn within 14 days of regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-01-15'),
+                    'appInDate' => Carbon::parse('2015-01-21'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // AppIn not within 14 days of regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'appOutDate' => Carbon::parse('2015-01-02'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPIN_LATE', ApiTeamApplicationValidator::MAX_DAYS_TO_APPROVE_APPLICATION],
+                ],
+                true,
+            ],
+            // Appr within 14 days of regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-01-15'),
+                    'appInDate' => Carbon::parse('2015-01-18'),
+                    'apprDate' => Carbon::parse('2015-01-21'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [],
+                true,
+            ],
+            // Appr not within 14 days of regDate
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'appOutDate' => Carbon::parse('2015-01-02'),
+                    'appInDate' => Carbon::parse('2015-01-03'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPR_LATE', ApiTeamApplicationValidator::MAX_DAYS_TO_APPROVE_APPLICATION],
+                ],
+                true,
+            ],
+
+            // RegDate in future
+            [
+                [
+                    'regDate' => Carbon::parse('2015-02-01'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_REG_DATE_IN_FUTURE'],
+                ],
+                false,
+            ],
+            // WdDate in future
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => Carbon::parse('2015-01-14'),
+                    'wdDate' => Carbon::parse('2015-02-14'),
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_WD_DATE_IN_FUTURE'],
+                ],
+                false,
+            ],
+            // ApprDate in future
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => Carbon::parse('2015-01-14'),
+                    'apprDate' => Carbon::parse('2015-02-14'),
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPR_DATE_IN_FUTURE'],
+                ],
+                false,
+            ],
+            // AppInDate in future
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-01-14'),
+                    'appInDate' => Carbon::parse('2015-02-14'),
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPIN_DATE_IN_FUTURE'],
+                ],
+                false,
+            ],
+            // AppOutDate in future
+            [
+                [
+                    'regDate' => Carbon::parse('2015-01-14'),
+                    'appOutDate' => Carbon::parse('2015-02-14'),
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'tmlpRegistration' => 1234,
+                    'incomingQuarter' => 1234,
+                    'committedTeamMember' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                [
+                    ['TMLPREG_APPOUT_DATE_IN_FUTURE'],
+                ],
+                false,
+            ],
+        ];
+    }
+
+    //
+    // validateTravel()
+    //
+
+    /**
+     * @dataProvider providerValidateTravelPasses
+     */
+    public function testValidateTravelPasses($data, $statsReport)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $this->setSetting('travelDueByDate', 'classroom2Date');
+
+        $validator = $this->getObjectMock([
+            'addMessage',
+        ], [$statsReport]);
+
+        $validator->expects($this->never())
+            ->method('addMessage');
+
+        $result = $validator->validateTravel($data);
+
+        $this->assertTrue($result);
+    }
+
+    public function providerValidateTravelPasses()
+    {
+        $nextQuarter = $this->getModelMock();
+        $futureQuarter = $this->getModelMock();
+
+        $statsReport = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'classroom2Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+            'nextQuarter' => $nextQuarter,
+        ]);
+        $statsReport->center = null;
+
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 4, 10);
+
+        return [
+            // validateTravel Passes When Before Second Classroom
+            [
+                [
+                    'travel' => null,
+                    'room' => null,
+                    'comment' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+            ],
+            // validateTravel Passes When Travel And Room Complete
+            [
+                [
+                    'travel' => true,
+                    'room' => true,
+                    'comment' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+            ],
+            // validateTravel Passes When Comments Provided
+            [
+                [
+                    'travel' => null,
+                    'room' => null,
+                    'comment' => 'Travel and rooming booked by May 4',
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerValidateTravelIgnored
+     */
+    public function testValidateTravelIgnoredWhenWdSet($data, $statsReport)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $this->setSetting('travelDueByDate', 'classroom2Date');
+
+        $validator = $this->getObjectMock([
+            'addMessage',
+        ], [$statsReport]);
+
+        $validator->expects($this->never())
+            ->method('addMessage');
+
+        $result = $validator->validateTravel($data);
+
+        $this->assertTrue($result);
+    }
+
+    public function providerValidateTravelIgnored()
+    {
+        $nextQuarter = $this->getModelMock();
+        $futureQuarter = $this->getModelMock();
+
+        $statsReport = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'classroom2Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+            'nextQuarter' => $nextQuarter,
+        ]);
+        $statsReport->center = null;
+
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 5, 8);
+
+        return [
+            // validateTravel Ignored When Wd Set
+            [
+                [
+                    'travel' => null,
+                    'room' => null,
+                    'comment' => null,
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'withdrawCode' => 1234,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+            ],
+            // validateTravel Ignored When Incoming Weekend Equals Future
+            [
+                [
+                    'travel' => null,
+                    'room' => null,
+                    'comment' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $futureQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerValidateTravelFails
+     */
+    public function testValidateTravelFails($data, $statsReport, $messages, $expectedResult)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $this->setSetting('travelDueByDate', 'classroom2Date');
+
+        $validator = $this->getObjectMock([
+            'addMessage',
+        ], [$statsReport]);
+
+        $this->setupMessageMocks($validator, $messages);
+
+        $result = $validator->validateTravel($data);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerValidateTravelFails()
+    {
+        $nextQuarter = $this->getModelMock();
+        $futureQuarter = $this->getModelMock();
+
+        $statsReport = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'classroom2Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+            'endWeekendDate' => Carbon::createFromDate(2015, 5, 29)->startOfDay(),
+            'nextQuarter' => $nextQuarter,
+        ]);
+        $statsReport->center = null;
+
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 5, 8);
+
+        $statsReportLastTwoWeeks = clone $statsReport;
+        $statsReportLastTwoWeeks->reportingDate = Carbon::createFromDate(2015, 5, 15);
+
+        return [
+            // ValidateTravel Fails When Missing Travel
+            [
+                [
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+                [
+                    ['TEAMAPP_TRAVEL_COMMENT_MISSING'],
+                ],
+                false,
+            ],
+            // ValidateTravel Fails When Missing Room
+            [
+                [
+                    'travel' => true,
+                    'room' => null,
+                    'comment' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReport,
+                [
+                    ['TEAMAPP_ROOM_COMMENT_MISSING'],
+                ],
+                false,
+            ],
+            // ValidateTravel Throws Warning When Missing Room In Last 2 Weeks
+            [
+                [
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => 'By 5/15/2015',
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReportLastTwoWeeks,
+                [
+                    ['TEAMAPP_TRAVEL_COMMENT_REVIEW'],
+                ],
+                true,
+            ],
+            // ValidateTravel Throws Warning When Missing Room In Last 2 Weeks
+            [
+                [
+                    'travel' => true,
+                    'room' => null,
+                    'comment' => 'By 5/15/2015',
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'teamYear' => 1,
+                    'center' => 1234,
+                    'isReviewer' => false,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                ],
+                $statsReportLastTwoWeeks,
+                [
+                    ['TEAMAPP_ROOM_COMMENT_REVIEW'],
+                ],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerValidateReviewer
+     */
+    public function testValidateReviewer($data, $messages, $expectedResult)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $validator = $this->getObjectMock([
+            'addMessage',
+        ]);
+
+        $this->setupMessageMocks($validator, $messages);
+
+        $result = $validator->validateReviewer($data);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerValidateReviewer()
+    {
+        return [
+            // Team 1 and not a reviewer
+            [
+                [
+                    'teamYear' => 1,
+                    'isReviewer' => false,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => 1234,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => null,
+                ],
+                [],
+                true,
+            ],
+            // Team 2 and not a reviewer
+            [
+                [
+                    'teamYear' => 2,
+                    'isReviewer' => false,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => 1234,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => null,
+                ],
+                [],
+                true,
+            ],
+            // Team 1 and a reviewer
+            [
+                [
+                    'teamYear' => 1,
+                    'isReviewer' => true,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => 1234,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => null,
+                ],
+                [
+                    ['TEAMAPP_REVIEWER_TEAM1'],
+                ],
+                false,
+            ],
+            // Team 2 and not a reviewer
+            [
+                [
+                    'teamYear' => 2,
+                    'isReviewer' => true,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'phone' => '555-555-5555',
+                    'center' => 1234,
+                    'regDate' => Carbon::parse('2015-01-07'),
+                    'appOutDate' => null,
+                    'appInDate' => null,
+                    'apprDate' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => 1234,
+                    'tmlpRegistration' => 1234,
+                    'committedTeamMember' => 1234,
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => null,
+                ],
+                [],
+                true,
+            ],
+        ];
+    }
+
+    //
+    // Helpers
+    //
+
+    /**
+     * @dataProvider providerIsStartingNextQuarter
+     */
+    public function testIsStartingNextQuarter($data, $statsReport, $expected)
+    {
+        $data = Domain\TeamApplication::fromArray($data);
+
+        $validator = $this->getObjectMock([], [$statsReport]);
+
+        $this->assertEquals($expected, $validator->isStartingNextQuarter($data));
+    }
+
+    public function providerIsStartingNextQuarter()
+    {
+        $nextQuarter = $this->getModelMock();
+        $futureQuarter = $this->getModelMock();
+
+        $statsReport = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'nextQuarter' => $nextQuarter,
+        ]);
+        return [
+            // Is Starting Next Quarter
+            [
+                [
+                    'incomingQuarter' => $nextQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 1,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                true,
+            ],
+            // Not Starting Next Quarter
+            [
+                [
+                    'incomingQuarter' => $futureQuarter->id,
+                    // the below values are not referenced and don't change
+                    'firstName' => 'Keith',
+                    'lastName' => 'Stone',
+                    'email' => 'unit_test@tmlpstats.com',
+                    'center' => 1234,
+                    'teamYear' => 1,
+                    'regDate' => Carbon::parse('2015-01-01'),
+                    'isReviewer' => false,
+                    'phone' => '555-555-5555',
+                    'tmlpRegistration' => 1234,
+                    'appOutDate' => Carbon::parse('2015-01-01'),
+                    'appInDate' => Carbon::parse('2015-01-01'),
+                    'apprDate' => Carbon::parse('2015-01-01'),
+                    'wdDate' => Carbon::parse('2015-01-01'),
+                    'committedTeamMember' => 1234,
+                    'withdrawCode' => 1234,
+                    'comment' => 'asdf qwerty',
+                    'travel' => true,
+                    'room' => true,
+                ],
+                $statsReport,
+                false,
+            ],
+        ];
+    }
+}

--- a/src/tests/functional/Api/ApplicationTest.php
+++ b/src/tests/functional/Api/ApplicationTest.php
@@ -472,7 +472,6 @@ class ApplicationTest extends FunctionalTestAbstract
         ];
     }
 
-
     public function testApiThrowsExceptionForInvalidDateInStash()
     {
         $reportingDate = Carbon::parse('this thursday', $this->center->timezone)

--- a/src/tests/functional/Api/ApplicationTest.php
+++ b/src/tests/functional/Api/ApplicationTest.php
@@ -198,7 +198,7 @@ class ApplicationTest extends FunctionalTestAbstract
             'center' => $this->center->abbreviation,
             'reportingDate' => $reportingDate,
             'data' => [
-                'tmlpRegistration' => $this->application->id,
+                'id' => $this->application->id,
                 'appOutDate' => '2016-04-09',
                 'appInDate' => '2016-04-10',
                 'apprDate' => '2016-04-11',
@@ -241,7 +241,10 @@ class ApplicationTest extends FunctionalTestAbstract
         ];
     }
 
-    public function testStashFailsValidation()
+    /**
+     * @dataProvider providerStashFailsValidation
+     */
+    public function testStashFailsValidation($id)
     {
         $reportingDate = '2016-04-15';
 
@@ -250,7 +253,6 @@ class ApplicationTest extends FunctionalTestAbstract
             'center' => $this->center->abbreviation,
             'reportingDate' => $reportingDate,
             'data' => [
-                'tmlpRegistration' => $this->application->id,
                 'appOutDate' => '2016-04-09',
                 'appInDate' => '2016-04-10',
                 'apprDate' => '2016-04-08',
@@ -259,6 +261,10 @@ class ApplicationTest extends FunctionalTestAbstract
                 'incomingQuarter' => $this->quarter->id,
             ],
         ];
+
+        if ($id) {
+            $parameters['data']['id'] = $this->application->id;
+        }
 
         $report = $this->report->toArray();
         $applicationDataId = $this->applicationData->id;
@@ -276,6 +282,14 @@ class ApplicationTest extends FunctionalTestAbstract
         $this->assertEquals('2016-04-09', $result->appOutDate->toDateString());
         $this->assertEquals('2016-04-10', $result->appInDate->toDateString());
         $this->assertEquals('2016-04-08', $result->apprDate->toDateString());
+    }
+
+    public function providerStashFailsValidation()
+    {
+        return [
+            ['id'], // Include application id
+            [null], // Do not include application id
+        ];
     }
 
     /**
@@ -454,7 +468,7 @@ class ApplicationTest extends FunctionalTestAbstract
         return [
             ['Application.allForCenter'],
             ['Application.getWeekData'],
-            // ['Application.stash'],
+            ['Application.stash'],
         ];
     }
 
@@ -470,7 +484,7 @@ class ApplicationTest extends FunctionalTestAbstract
             'reportingDate' => $reportingDate,
             'center' => $this->center->id,
             'data' => [
-                'tmlpRegistration' => $this->application->id,
+                'id' => $this->application->id,
             ],
         ];
 

--- a/src/tests/functional/Api/ApplicationTest.php
+++ b/src/tests/functional/Api/ApplicationTest.php
@@ -198,10 +198,13 @@ class ApplicationTest extends FunctionalTestAbstract
             'center' => $this->center->abbreviation,
             'reportingDate' => $reportingDate,
             'data' => [
-                'tmlpRegistrationId' => $this->application->id,
-                'appOutDate' => '2016-04-17',
-                'apprDate' => '2016-04-23',
-                'committedTeamMemberId' => 1,
+                'tmlpRegistration' => $this->application->id,
+                'appOutDate' => '2016-04-09',
+                'appInDate' => '2016-04-10',
+                'apprDate' => '2016-04-11',
+                'committedTeamMember' => 1,
+                'teamYear' => 1,
+                'incomingQuarter' => $this->quarter->id,
             ],
         ];
 
@@ -217,6 +220,7 @@ class ApplicationTest extends FunctionalTestAbstract
 
         $expectedResponse = [
             'success' => true,
+            'valid' => true,
         ];
 
         $this->post('/api', $parameters)->seeJsonHas($expectedResponse);
@@ -224,16 +228,54 @@ class ApplicationTest extends FunctionalTestAbstract
 
         $this->assertEquals(1, count($result1));
         $result = $result1[0];
-        $this->assertEquals('2016-04-17', $result->appOutDate->toDateString());
-        $this->assertEquals('2016-04-23', $result->apprDate->toDateString());
+        $this->assertEquals('2016-04-09', $result->appOutDate->toDateString());
+        $this->assertEquals('2016-04-10', $result->appInDate->toDateString());
+        $this->assertEquals('2016-04-11', $result->apprDate->toDateString());
     }
 
     public function providerStash()
     {
         return [
-            ['2016-04-08'], // Non-existent report
+            ['2016-04-22'], // Non-existent report
             ['2016-04-15'], // Existing report
         ];
+    }
+
+    public function testStashFailsValidation()
+    {
+        $reportingDate = '2016-04-15';
+
+        $parameters = [
+            'method' => 'Application.stash',
+            'center' => $this->center->abbreviation,
+            'reportingDate' => $reportingDate,
+            'data' => [
+                'tmlpRegistration' => $this->application->id,
+                'appOutDate' => '2016-04-09',
+                'appInDate' => '2016-04-10',
+                'apprDate' => '2016-04-08',
+                'committedTeamMember' => 1,
+                'teamYear' => 1,
+                'incomingQuarter' => $this->quarter->id,
+            ],
+        ];
+
+        $report = $this->report->toArray();
+        $applicationDataId = $this->applicationData->id;
+
+        $expectedResponse = [
+            'success' => true,
+            'valid' => false,
+        ];
+
+        $this->post('/api', $parameters)->seeJsonHas($expectedResponse);
+        $result1 = App::make(Api\SubmissionData::class)->allForType($this->center, new Carbon($reportingDate), Domain\TeamApplication::class);
+
+        $this->assertEquals(1, count($result1));
+        $result = $result1[0];
+        $this->assertEquals('2016-04-09', $result->appOutDate->toDateString());
+        $this->assertEquals('2016-04-10', $result->appInDate->toDateString());
+        $this->assertEquals('2016-04-08', $result->apprDate->toDateString());
     }
 
     /**
@@ -412,7 +454,34 @@ class ApplicationTest extends FunctionalTestAbstract
         return [
             ['Application.allForCenter'],
             ['Application.getWeekData'],
-            ['Application.stash'],
+            // ['Application.stash'],
         ];
+    }
+
+
+    public function testApiThrowsExceptionForInvalidDateInStash()
+    {
+        $reportingDate = Carbon::parse('this thursday', $this->center->timezone)
+            ->startOfDay()
+            ->toDateString();
+
+        $parameters = [
+            'method' => 'Application.stash',
+            'reportingDate' => $reportingDate,
+            'center' => $this->center->id,
+            'data' => [
+                'tmlpRegistration' => $this->application->id,
+            ],
+        ];
+
+        $expectedResponse = [
+            'success' => false,
+            'error' => [
+                'message' => 'Reporting date must be a Friday.',
+            ],
+        ];
+
+        $headers = ['Accept' => 'application/json'];
+        $this->post('/api', $parameters, $headers)->seeJsonHas($expectedResponse);
     }
 }

--- a/src/tests/unit/Traits/MocksQuarters.php
+++ b/src/tests/unit/Traits/MocksQuarters.php
@@ -5,6 +5,8 @@ use TmlpStats\Quarter;
 
 trait MocksQuarters
 {
+    protected static $idOffset = 0;
+
     /**
      * Get a Quarter object mock
      *
@@ -25,12 +27,16 @@ trait MocksQuarters
             'getClassroom2Date',
             'getClassroom3Date',
             'getQuarterDate',
+            'getNextQuarter',
         ];
         $methods = $this->mergeMockMethods($defaultMethods, $methods);
 
         $quarter = $this->getMockBuilder(Quarter::class)
                         ->setMethods($methods)
                         ->getMock();
+
+        static::$idOffset++;
+        $quarter->id = static::$idOffset;
 
         if (!$data) {
             return $quarter;
@@ -58,6 +64,10 @@ trait MocksQuarters
 
         $firstWeekDate = isset($data['firstWeekDate'])
             ? $data['firstWeekDate']
+            : null;
+
+        $nextQuarter = isset($data['nextQuarter'])
+            ? $data['nextQuarter']
             : null;
 
         if (!$firstWeekDate && $startWeekendDate) {
@@ -89,6 +99,9 @@ trait MocksQuarters
                         ? $data[$field]
                         : null;
                 }));
+
+        $quarter->method('getNextQuarter')
+                ->willReturn($nextQuarter);
 
         return $quarter;
     }


### PR DESCRIPTION
Adding a validation path for API based submissions.

Call into the new `ApiValidationManager` by passing an array like the following to `ApiValidationManager::run()`:
```
$data = [
    'teamApplication' => [...Array of team application domain objects],
    'teamMember' => [...Array of team member domain objects],
    'scoreboard' => [...Array of scoreboard objects],
    'course' => [...Array of course domain objects],
];
```

The run method will call all of the required validators based on the input.

Notes:
- New validators are prefixed with Api and are named after their api name.
- `ApiCourseValidator` and `ApiScoreboardValidator` are the same as the base validators, but are derived to have a unique name.
- `ApiTeamApplicationValidator` and `ApiTeamMemberValidator` are duplicates of the original classes with the necessary changes. We'll have to be careful to copy change over if there are any updates to the validators before GA.
- We're going to need to to write a new Messages class that maps the same message key to a new message text since the old text may not make sense in all cases.
- We're going to have to come up with a new way to reference objects now that they don't have a row/column number.
- `ApiCenterGamesValidator` needs to new way of pulling the TeamApplications quarter starting totals. We'll have to pull it from the db somewhere.
- None of this PR has been tested, so there are most likely bugs to work out.
- I'm not 100% sure the `GeneratesApiMessages` trait is going to work as we want by overriding the parent's implementation.