### PR TITLE
Pass down course meta data

### DIFF
--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -101,7 +101,7 @@ class Application extends ApiBase
             $submissionData = App::make(SubmissionData::class);
             $found = $submissionData->allForType($center, $reportingDate, Domain\TeamApplication::class);
             foreach ($found as $app) {
-                $allApplications[$app->tmlpRegistrationId] = $app;
+                $allApplications[$app->id] = $app;
             }
         }
 

--- a/src/app/Api/Course.php
+++ b/src/app/Api/Course.php
@@ -194,12 +194,10 @@ class Course extends ApiBase
         $report = LocalReport::getStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $course, $courseId);
 
-        $course->meta = $this->getCourseMeta($course, $center, $reportingDate);
-
         return [
             'success' => true,
             'storedId' => $courseId,
-            'course' => $course,
+            'meta' => $this->getCourseMeta($course, $center, $reportingDate),
             'valid' => $validationResults['valid'],
             'messages' => $validationResults['messages'],
         ];

--- a/src/app/Api/Course.php
+++ b/src/app/Api/Course.php
@@ -101,7 +101,8 @@ class Course extends ApiBase
             $submissionData = App::make(SubmissionData::class);
             $found = $submissionData->allForType($center, $reportingDate, Domain\Course::class);
             foreach ($found as $courseData) {
-                $allCourses[$courseData->courseId] = $courseData;
+                $courseData->meta['localChanges'] = true;
+                $allCourses[$courseData->id] = $courseData;
             }
         }
 
@@ -112,6 +113,10 @@ class Course extends ApiBase
 
             return $a->startDate->lt($b->startDate) ? -1 : 1;
         });
+
+        foreach ($allCourses as $course) {
+            $course->meta = $this->getCourseMeta($course, $center, $reportingDate);
+        }
 
         return array_values($allCourses);
     }
@@ -189,9 +194,12 @@ class Course extends ApiBase
         $report = LocalReport::getStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $course, $courseId);
 
+        $course->meta = $this->getCourseMeta($course, $center, $reportingDate);
+
         return [
             'success' => true,
             'storedId' => $courseId,
+            'course' => $course,
             'valid' => $validationResults['valid'],
             'messages' => $validationResults['messages'],
         ];
@@ -222,5 +230,25 @@ class Course extends ApiBase
         $courseData->save();
 
         return $courseData->load('course', 'course.center', 'statsReport');
+    }
+
+    protected function getCourseMeta(Domain\Course $course, $center, $reportingDate)
+    {
+        $isFirstWeek = Models\Quarter::isFirstWeek($center->region);
+
+        // TODO: fix this so we don't assume the course starts on a Saturday
+        $courseReportDate = $course->startDate->copy()->addDays(6);
+        $isPastCourse = $reportingDate->gt($courseReportDate);
+        $isCompletionWeek = $reportingDate->eq($courseReportDate);
+
+        $meta = $course->meta;
+        $meta['canEditQuarterStart'] = ($course->id < 0 || $isFirstWeek);
+        $meta['canEditGuestGame'] = !$isPastCourse;
+        $meta['canEditCurrent'] = !$isPastCourse;
+        $meta['canEditCompletion'] = $isCompletionWeek;
+        $meta['isPastCourse'] = $isPastCourse;
+        $meta['isCompletionReportWeek'] = $isCompletionWeek;
+
+        return $meta;
     }
 }

--- a/src/app/Domain/Course.php
+++ b/src/app/Domain/Course.php
@@ -9,6 +9,8 @@ use TmlpStats\Api\Exceptions as ApiExceptions;
  */
 class Course extends ParserDomain
 {
+    public $meta = [];
+
     protected static $validProperties = [
         'center' => [
             'owner' => 'course',
@@ -167,5 +169,14 @@ class Course extends ParserDomain
 
             $this->copyTarget($target, $k, $v);
         }
+    }
+
+    public function toArray()
+    {
+        $output = parent::toArray();
+
+        $output['meta'] = $this->meta;
+
+        return $output;
     }
 }

--- a/src/resources/assets/js/submission/courses/components.jsx
+++ b/src/resources/assets/js/submission/courses/components.jsx
@@ -168,11 +168,9 @@ class _EditCreate extends CoursesBase {
     saveCourseData(data) {
         this.props.dispatch(saveCourse(this.props.params.centerId, this.reportingDateString(), data)).done((result) => {
             if (result.success && result.storedId) {
-                const courseId = result.storedId
-                // We're replacing the local copy with the version returned during the save
-                // this makes sure any updates to the meta data is updated everywhere
-                this.props.dispatch(coursesCollection.replaceItem(result.course))
-                this.props.dispatch(chooseCourse(courseId, this.getCourseById(courseId)))
+                data = objectAssign({}, data, {id: result.storedId, meta: result.meta})
+                this.props.dispatch(coursesCollection.replaceItem(data))
+                this.props.dispatch(chooseCourse(data.id, this.getCourseById(data.id)))
             }
             this.props.router.push(this.baseUri() + '/courses')
         })


### PR DESCRIPTION
Meta data contains info about which fields are editable based on when the course occurred. This will make it easier to make fields editable down the road based on config (e.g. make quarter start dates temporarily editable)

Courses::stash now also returns the meta object. This allows up to update the course in the state tree with any updated meta data from the stash operation.