### PR TITLE
Add method to fetch list of data that has not changed since last week…

### DIFF
--- a/src/app/Api/Course.php
+++ b/src/app/Api/Course.php
@@ -60,7 +60,7 @@ class Course extends ApiBase
         return $course->load('center');
     }
 
-    public function allForCenter(Models\Center $center, $includeInProgress = false, Carbon $reportingDate = null)
+    public function allForCenter(Models\Center $center, Carbon $reportingDate = null, $includeInProgress = false)
     {
         if ($reportingDate === null) {
             $reportingDate = LocalReport::getReportingDate($center);
@@ -238,6 +238,26 @@ class Course extends ApiBase
         $courseData->save();
 
         return $courseData->load('course', 'course.center', 'statsReport');
+    }
+
+    public function getUnchangedFromLastReport(Models\Center $center, Carbon $reportingDate)
+    {
+        $results = [];
+
+        $allData = $this->allForCenter($center, $reportingDate, true);
+        foreach ($allData as $dataObject) {
+            if (!array_get($dataObject->meta, 'localChanges', false)) {
+                $results[] = $dataObject;
+            }
+        }
+
+        return $results;
+    }
+
+    public function getChangedFromLastReport(Models\Center $center, Carbon $reportingDate)
+    {
+        $collection = App::make(SubmissionData::class)->allForType($center, $reportingDate, Domain\Course::class);
+        return array_flatten($collection->getDictionary());
     }
 
     protected function getCourseMeta(Domain\Course $course, Models\Center $center, Carbon $reportingDate)

--- a/src/app/Api/SubmissionData.php
+++ b/src/app/Api/SubmissionData.php
@@ -1,6 +1,7 @@
 <?php
 namespace TmlpStats\Api;
 
+use App;
 use Carbon\Carbon;
 use Illuminate\Auth\Guard;
 use Illuminate\Http\Request;
@@ -85,9 +86,7 @@ class SubmissionData extends AuthenticatedApiBase
      */
     public function store(Models\Center $center, Carbon $reportingDate, $obj)
     {
-        if ($reportingDate->dayOfWeek !== Carbon::FRIDAY) {
-            throw new ApiExceptions\BadRequestException('Reporting date must be a Friday.');
-        }
+        App::make(SubmissionCore::class)->checkCenterDate($center, $reportingDate);
         $userId = $this->context->getUser()->id;
 
         $conf = $this->combinedTypeMapping[get_class($obj)];

--- a/src/app/Api/ValidationData.php
+++ b/src/app/Api/ValidationData.php
@@ -7,46 +7,120 @@ use TmlpStats as Models;
 use TmlpStats\Api\Base\AuthenticatedApiBase;
 use TmlpStats\Api\Exceptions as ApiExceptions;
 use TmlpStats\Domain;
+use TmlpStats\Traits;
 
 /**
  * Validation data
  */
 class ValidationData extends AuthenticatedApiBase
 {
+    use Traits\GeneratesApiMessages;
+
+    // updateRequired: Not all objects require updates every week, but some do. For those that do,
+    //                 if no update is needed, they'll need to take some action to confirm the
+    //                 data is the same. That "confirmation" will create a submissionData entry
+    protected $dataTypesConf = [
+        'applications' => [
+            'apiClass' => Application::class,
+            'typeName' => 'application',
+            'updateRequired' => false,
+        ],
+        'courses' => [
+            'apiClass' => Course::class,
+            'typeName' => 'course',
+            'updateRequired' => false,
+        ],
+        'scoreboard' => [
+            'apiClass' => Scoreboard::class,
+            'typeName' => 'center games',
+            'updateRequired' => true,
+        ],
+    ];
+
     public function validate(Models\Center $center, Carbon $reportingDate)
     {
         $this->assertAuthz($this->context->can('viewSubmissionUi', $center));
         App::make(SubmissionCore::class)->checkCenterDate($center, $reportingDate);
 
-        $validationResults = $this->validateSubmissionData($center, $reportingDate);
+        $report = LocalReport::getStatsReport($center, $reportingDate);
+
+        $results = array_merge_recursive(
+            $this->validateSubmissionData($report),
+            $this->validateStaleData($report)
+        );
+        $isValid = true;
+
+        foreach ($results as $group => $groupData) {
+            foreach ($groupData as $message) {
+                if ($message['type'] == 'error') {
+                    $isValid = false;
+                    break;
+                }
+            }
+        }
 
         return [
             'success' => true,
-            'results' => $validationResults,
+            'valid' => $isValid,
+            'messages' => $results,
         ];
     }
 
-    protected function validateSubmissionData(Models\Center $center, Carbon $reportingDate)
+    protected function validateSubmissionData(Models\StatsReport $report)
     {
-        $types = [
-            'applications' => Domain\TeamApplication::class,
-            'courses' => Domain\Course::class,
-            'scoreboard' => Domain\Scoreboard::class,
-        ];
-        $report = LocalReport::getStatsReport($center, $reportingDate);
+        $data = [];
+        foreach ($this->dataTypesConf as $group => $conf) {
+            $data[$group] = App::make($conf['apiClass'])->getChangedFromLastReport(
+                $report->center,
+                $report->reportingDate
+            );
+        }
 
         $results = [];
-        foreach ($types as $group => $type) {
-            $submissionData = App::make(SubmissionData::class)->allForType($center, $reportingDate, $type);
-
-            foreach ($submissionData as $object) {
-                $id = $object->getId();
+        foreach ($data as $group => $groupData) {
+            if (!isset($results[$group])) {
+                $results[$group] = [];
+            }
+            foreach ($groupData as $object) {
+                $id = $object->getKey();
                 $validationResults = $this->validateObject($report, $object, $id);
 
-                $results[$group][] = [
-                    'valid' => $validationResults['valid'],
-                    'messages' => $validationResults['messages'],
-                ];
+                if ($validationResults['messages']) {
+                    $results[$group] = array_merge($results[$group], $validationResults['messages']);
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    protected function validateStaleData(Models\StatsReport $report)
+    {
+        $data = [];
+        foreach ($this->dataTypesConf as $group => $conf) {
+            $data[$group] = App::make($conf['apiClass'])->getUnchangedFromLastReport(
+                $report->center,
+                $report->reportingDate
+            );
+        }
+
+        $results = [];
+        foreach ($data as $group => $groupData) {
+            $conf = $this->dataTypesConf[$group];
+            foreach ($groupData as $object) {
+                $id = $object->getKey();
+                $validationResults = $this->validateObject($report, $object, $id);
+
+                if ($conf['updateRequired']) {
+                    // Need to set $this->data so addMessage can get the object's id
+                    $this->data = $object;
+                    $validationResults['valid'] = false;
+                    $validationResults['messages'][] = $this->addMessage('VALDATA_DATA_MISSING_UPDATE', $conf['typeName']);
+                }
+
+                if ($validationResults['messages']) {
+                    $results[$group] = array_merge($results[$group], $validationResults['messages']);
+                }
             }
         }
 

--- a/src/app/Contracts/Referenceable.php
+++ b/src/app/Contracts/Referenceable.php
@@ -3,5 +3,5 @@ namespace TmlpStats\Contracts;
 
 interface Referenceable
 {
-    public function getId();
+    public function getKey();
 }

--- a/src/app/Domain/ParserDomain.php
+++ b/src/app/Domain/ParserDomain.php
@@ -36,7 +36,7 @@ class ParserDomain implements Arrayable, \JsonSerializable, Referenceable
      *
      * @return string
      */
-    public function getId()
+    public function getKey()
     {
         $prop = $this->_refProp;
         return $this->$prop;

--- a/src/app/Domain/Scoreboard.php
+++ b/src/app/Domain/Scoreboard.php
@@ -32,7 +32,7 @@ class Scoreboard implements Arrayable, Referenceable
      *
      * @return string
      */
-    public function getId()
+    public function getKey()
     {
         return $this->week->toDateString();
     }

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -8,6 +8,8 @@ use TmlpStats as Models;
  */
 class TeamApplication extends ParserDomain
 {
+    public $meta = [];
+
     protected static $validProperties = [
         'firstName' => [
             'owner' => 'person',
@@ -154,5 +156,14 @@ class TeamApplication extends ParserDomain
             }
             $this->copyTarget($target, $k, $v, $conf);
         }
+    }
+
+    public function toArray()
+    {
+        $output = parent::toArray();
+
+        $output['meta'] = $this->meta;
+
+        return $output;
     }
 }

--- a/src/app/Http/Controllers/ApiController.php
+++ b/src/app/Http/Controllers/ApiController.php
@@ -79,8 +79,8 @@ class ApiController extends ApiControllerBase
     {
         return App::make(Api\Application::class)->allForCenter(
             $this->parse($input, 'center', 'Center'),
-            $this->parse($input, 'includeInProgress', 'bool', false),
-            $this->parse($input, 'reportingDate', 'date', false)
+            $this->parse($input, 'reportingDate', 'date', false),
+            $this->parse($input, 'includeInProgress', 'bool', false)
         );
     }
     protected function Application__getWeekData($input)
@@ -134,8 +134,8 @@ class ApiController extends ApiControllerBase
     {
         return App::make(Api\Course::class)->allForCenter(
             $this->parse($input, 'center', 'Center'),
-            $this->parse($input, 'includeInProgress', 'bool', false),
-            $this->parse($input, 'reportingDate', 'date', false)
+            $this->parse($input, 'reportingDate', 'date', false),
+            $this->parse($input, 'includeInProgress', 'bool', false)
         );
     }
     protected function Course__getWeekData($input)

--- a/src/app/Message.php
+++ b/src/app/Message.php
@@ -825,6 +825,13 @@ class Message
             'format' => 'Only Team 2 can be reviewers. Please check that the team year and reviewer statuses are correct.',
             'arguments' => [],
         ],
+        'VALDATA_DATA_MISSING_UPDATE' => [
+            'type' => Message::ERROR,
+            'format' => '%%type%% has not been updated since last week. Please confirm that no changes are needed.',
+            'arguments' => [
+                '%%type%%'
+            ],
+        ],
     ];
 
     protected $section = '';

--- a/src/app/Traits/GeneratesApiMessages.php
+++ b/src/app/Traits/GeneratesApiMessages.php
@@ -1,6 +1,7 @@
 <?php
 namespace TmlpStats\Traits;
 
+use TmlpStats\Contracts\Referenceable;
 use TmlpStats\Message;
 use TmlpStats\Settings\Setting;
 
@@ -57,12 +58,12 @@ trait GeneratesApiMessages
         $offset = null;
 
         $arguments = func_get_args();
-        if (method_exists($this, 'getOffset') && isset($this->data)) {
-            $offset = $this->getOffset($this->data);
+        if (isset($this->data) && $this->data instanceof Referenceable) {
+            $offset = $this->data->getKey();
         }
         array_splice($arguments, 1, 0, [$offset]);
 
-        $this->messages[] = $this->callMessageAdd($message, $arguments);
+        return $this->messages[] = $this->callMessageAdd($message, $arguments);
     }
 
     /**

--- a/src/config/reports.yml
+++ b/src/config/reports.yml
@@ -55,11 +55,11 @@ api:
         params:
           - name: center
             type: Center
-          - name: includeInProgress
-            type: bool
-            required: false
           - name: reportingDate
             type: date
+            required: false
+          - name: includeInProgress
+            type: bool
             required: false
       getWeekData:
         desc: Get the weekly data for an application
@@ -117,11 +117,11 @@ api:
         params:
           - name: center
             type: Center
-          - name: includeInProgress
-            type: bool
-            required: false
           - name: reportingDate
             type: date
+            required: false
+          - name: includeInProgress
+            type: bool
             required: false
       getWeekData:
         desc: Get the weekly data for an course

--- a/src/public/js/api.js
+++ b/src/public/js/api.js
@@ -49,8 +49,8 @@ Api.Application = {
     List applications by center
     Parameters:
       center: Center
-      includeInProgress: bool
       reportingDate: date
+      includeInProgress: bool
     */
     allForCenter: function(params, callback, errback) {
         return apiCall('Application.allForCenter', params, (callback || null), (errback || null));
@@ -132,8 +132,8 @@ Api.Course = {
     List courses by center
     Parameters:
       center: Center
-      includeInProgress: bool
       reportingDate: date
+      includeInProgress: bool
     */
     allForCenter: function(params, callback, errback) {
         return apiCall('Course.allForCenter', params, (callback || null), (errback || null));

--- a/src/resources/assets/js/submission/applications/actions.js
+++ b/src/resources/assets/js/submission/applications/actions.js
@@ -11,8 +11,8 @@ export function loadApplications(centerId, reportingDate) {
         dispatch(loadState('loading'))
         return Api.Application.allForCenter({
             center: centerId,
+            reportingDate: reportingDate,
             includeInProgress: true,
-            reportingDate: reportingDate
         }).done((data) => {
             dispatch(initializeApplications(data))
         }).fail(() => {

--- a/src/resources/assets/js/submission/courses/actions.js
+++ b/src/resources/assets/js/submission/courses/actions.js
@@ -11,8 +11,8 @@ export function loadCourses(centerId, reportingDate) {
         dispatch(loadState('loading'))
         return Api.Course.allForCenter({
             center: centerId,
+            reportingDate: reportingDate,
             includeInProgress: true,
-            reportingDate: reportingDate
         }).done((data) => {
             dispatch(initializeCourses(data))
         }).fail(() => {

--- a/src/tests/functional/Api/ValidationDataObjectTest.php
+++ b/src/tests/functional/Api/ValidationDataObjectTest.php
@@ -99,43 +99,9 @@ class ValidationDataObjectTest extends FunctionalTestAbstract
         $this->api = App::make(Api\ValidationData::class);
     }
 
-    public function tearDown()
-    {
-        parent::tearDown();
-    }
-
     public function testValidate_unauthorized()
     {
         $this->expectException(Api\Exceptions\UnauthorizedException::class);
         $this->api->validate($this->center, $this->now);
-    }
-
-    public function testGetSubmittedData()
-    {
-        $this->context->withFakedAdmin()->install();
-
-        $submitted = $this->api->getSubmittedData($this->center, $this->reportingDate);
-
-        $this->assertEquals(0, count($submitted['applications']));
-        $this->assertEquals(0, count($submitted['scoreboard']));
-
-        $this->assertEquals(1, count($submitted['courses']));
-        $this->assertEquals($this->course2->id, $submitted['courses'][0]->getKey());
-    }
-
-    public function testGetUnsubmittedData()
-    {
-        $this->context->withFakedAdmin()->install();
-
-        $unsubmitted = $this->api->getUnsubmittedData($this->center, $this->reportingDate);
-
-        $this->assertEquals(0, count($unsubmitted['applications']));
-
-        $this->assertEquals(2, count($unsubmitted['courses']));
-        $this->assertEquals($this->course->id, $unsubmitted['courses'][0]->getKey());
-        $this->assertEquals($this->course3->id, $unsubmitted['courses'][1]->getKey());
-
-        $this->assertEquals(1, count($unsubmitted['scoreboard']));
-        $this->assertEquals($this->reportingDate->toDateString(), $unsubmitted['scoreboard'][0]['week']);
     }
 }

--- a/src/tests/functional/Api/ValidationDataObjectTest.php
+++ b/src/tests/functional/Api/ValidationDataObjectTest.php
@@ -24,7 +24,76 @@ class ValidationDataObjectTest extends FunctionalTestAbstract
     {
         parent::setUp();
 
+        $reportingDateStr = '2016-04-15';
+        $this->reportingDate = Carbon::parse($reportingDateStr);
+
         $this->center = Models\Center::abbreviation('VAN')->first();
+
+        $this->quarter = Models\Quarter::year(2016)->quarterNumber(1)->first();
+        $this->lastQuarter = Models\Quarter::year(2015)->quarterNumber(4)->first();
+
+        $this->report = $this->getReport($reportingDateStr, ['submitted_at' => null]);
+        $this->lastReport = $this->getReport('2016-04-08');
+        $this->lastGlobalReport = $this->getGlobalReport('2016-04-08', [$this->lastReport]);
+
+        // Setup course
+        $this->course = factory(Models\Course::class)->create([
+            'center_id' => $this->center->id,
+            'start_date' => Carbon::parse('2016-04-23'),
+        ]);
+        $this->course2 = factory(Models\Course::class)->create([
+            'center_id' => $this->center->id,
+            'start_date' => Carbon::parse('2016-08-13'),
+        ]);
+        $this->course3 = factory(Models\Course::class)->create([
+            'center_id' => $this->center->id,
+            'start_date' => Carbon::parse('2016-08-13'),
+        ]);
+        $this->lastWeekCourseData = Models\CourseData::firstOrCreate([
+            'course_id' => $this->course->id,
+            'stats_report_id' => $this->lastReport->id,
+            'quarter_start_ter' => 8,
+            'quarter_start_standardStarts' => 6,
+            'quarter_start_xfer' => 0,
+            'current_ter' => 28,
+            'current_standard_starts' => 22,
+            'current_xfer' => 2,
+        ]);
+        $this->lastWeekCourse2Data = Models\CourseData::firstOrCreate([
+            'course_id' => $this->course2->id,
+            'stats_report_id' => $this->lastReport->id,
+            'quarter_start_ter' => 0,
+            'quarter_start_standard_starts' => 0,
+            'quarter_start_xfer' => 0,
+            'current_ter' => 17,
+            'current_standard_starts' => 17,
+            'current_xfer' => 2,
+        ]);
+        $this->lastWeekCourse3Data = Models\CourseData::firstOrCreate([
+            'course_id' => $this->course3->id,
+            'stats_report_id' => $this->lastReport->id,
+            'quarter_start_ter' => 0,
+            'quarter_start_standard_starts' => 0,
+            'quarter_start_xfer' => 0,
+            'current_ter' => 8,
+            'current_standard_starts' => 8,
+            'current_xfer' => 0,
+        ]);
+
+        App::make(Api\Course::class)->stash($this->center, $this->reportingDate, [
+            'id' => $this->course2->id,
+            'startDate' => $this->course2->startDate,
+            'type' => $this->course2->type,
+            'quarterStartTer' => 0,
+            'quarterStartStandardStarts' => 0,
+            'quarterStartXfer' => 0,
+            'currentTer' => 23,
+            'currentStandardStarts' => 19,
+            'currentXfer' => 2,
+        ]);
+
+        $this->now = Carbon::parse("{$reportingDateStr} 18:45:00");
+        Carbon::setTestNow($this->now);
 
         $this->context = MockContext::defaults()->withCenter($this->center)->install();
         $this->api = App::make(Api\ValidationData::class);
@@ -39,5 +108,34 @@ class ValidationDataObjectTest extends FunctionalTestAbstract
     {
         $this->expectException(Api\Exceptions\UnauthorizedException::class);
         $this->api->validate($this->center, $this->now);
+    }
+
+    public function testGetSubmittedData()
+    {
+        $this->context->withFakedAdmin()->install();
+
+        $submitted = $this->api->getSubmittedData($this->center, $this->reportingDate);
+
+        $this->assertEquals(0, count($submitted['applications']));
+        $this->assertEquals(0, count($submitted['scoreboard']));
+
+        $this->assertEquals(1, count($submitted['courses']));
+        $this->assertEquals($this->course2->id, $submitted['courses'][0]->getKey());
+    }
+
+    public function testGetUnsubmittedData()
+    {
+        $this->context->withFakedAdmin()->install();
+
+        $unsubmitted = $this->api->getUnsubmittedData($this->center, $this->reportingDate);
+
+        $this->assertEquals(0, count($unsubmitted['applications']));
+
+        $this->assertEquals(2, count($unsubmitted['courses']));
+        $this->assertEquals($this->course->id, $unsubmitted['courses'][0]->getKey());
+        $this->assertEquals($this->course3->id, $unsubmitted['courses'][1]->getKey());
+
+        $this->assertEquals(1, count($unsubmitted['scoreboard']));
+        $this->assertEquals($this->reportingDate->toDateString(), $unsubmitted['scoreboard'][0]['week']);
     }
 }


### PR DESCRIPTION
This is part 1 of a 2 part change to validate mixed new and old data.

In this commit, I added methods to get a list of all data that has not changed since the last week's report.

A few notes:
- I changed the parameter order for `Api\Course::allForCenter()` and `Api\Application::allForCenter()` so that it matched TeamMember and Scoreboard. There's probably no need to allow for null reportingDates at this point, but leaving that for another commit.

- Changed the name of `Domain\ParserDomain::getId()` and `Domain\Scoreboard::getId()` to `getKey()` so that it works nicely with `Eloquent\Collection::getDictionary()`. The latter is a nice helper method to convert collections into arrays without flattening all of the items in the collection.

- The more work I do on the validation, the more I want to redesign the Messages class. It doesn't fit the way we do validation anymore so working with it is a bit awkward.