### PR TITLE
Don't send regional response promise on last week of quarter

### DIFF
--- a/src/app/Settings/Parsers/ReportDeadlinesParser.php
+++ b/src/app/Settings/Parsers/ReportDeadlinesParser.php
@@ -74,7 +74,7 @@ class ReportDeadlinesParser extends AbstractParser
     protected function mergeSettings($defaults, $settings)
     {
         foreach (['report', 'response'] as $type) {
-            if (!isset($settings[$type])) {
+            if (!isset($settings[$type]) || !$settings[$type]) {
                 unset($defaults[$type]);
                 continue;
             }

--- a/src/app/Settings/Parsers/ReportDeadlinesParser.php
+++ b/src/app/Settings/Parsers/ReportDeadlinesParser.php
@@ -54,6 +54,8 @@ class ReportDeadlinesParser extends AbstractParser
 
                 break;
             }
+        } else {
+            $deadlines = [];
         }
 
         return $this->prepareResults($deadlines);
@@ -73,6 +75,7 @@ class ReportDeadlinesParser extends AbstractParser
     {
         foreach (['report', 'response'] as $type) {
             if (!isset($settings[$type])) {
+                unset($defaults[$type]);
                 continue;
             }
 
@@ -158,6 +161,10 @@ class ReportDeadlinesParser extends AbstractParser
         ];
 
         foreach (['report', 'response'] as $type) {
+            if (!isset($results[$type]) || !$results[$type]) {
+                continue;
+            }
+
             $deadline = $results[$type];
 
             $dueDate  = $this->parseDueDate($deadline['dueDate']);

--- a/src/app/StatsReport.php
+++ b/src/app/StatsReport.php
@@ -95,6 +95,13 @@ class StatsReport extends Model
         }
 
         $due = $this->reportDeadlines['response'];
+
+        // No response required on last week
+        $quarterEndDate = $this->quarter->getQuarterEndDate($this->center);
+        if (!$due && $quarterEndDate && $this->reportingDate->eq($quarterEndDate)) {
+            return null;
+        }
+
         if (!$due) {
             $due = Carbon::create(
                 $this->reportingDate->year,

--- a/src/resources/views/emails/statssubmitted.blade.php
+++ b/src/resources/views/emails/statssubmitted.blade.php
@@ -19,7 +19,7 @@ We received them on {{ $submittedAt->format('l, F jS \a\t g:ia') }} your local t
     <br/>
 @endif
 
-@if (!$isResubmitted)
+@if (!$isResubmitted && $respondByDateTime)
 You are not complete yet. Your regional statistician will review your sheet and declare you complete by {{ $respondByDateTime->format('l \a\t g:ia') }} your local time.<br/>
 @endif
 <br/>
@@ -29,7 +29,7 @@ You are not complete yet. Your regional statistician will review your sheet and 
     <br/>
 @endif
 @if ($mobileDashUrl)
-    Share the team's scoreboard via email or text with this mobile friendly link: 
+    Share the team's scoreboard via email or text with this mobile friendly link:
     <a href="{{ $mobileDashUrl }}">{{ $mobileDashUrl }}</a><br/>
     <br/>
 @endif

--- a/src/tests/unit/Settings/ReportDeadlinesTest.php
+++ b/src/tests/unit/Settings/ReportDeadlinesTest.php
@@ -58,10 +58,8 @@ class ReportDeadlinesTest extends TestAbstract
                 $quarterDates,
                 $center,
                 [
-                    'report'   => Carbon::parse($reportingDate->toDateString(), $center->timezone)->setTime(19, 0, 59),
-                    'response' => Carbon::parse($reportingDate->toDateString(), $center->timezone)
-                                        ->addDay()
-                                        ->setTime(10, 0, 0),
+                    'report'   => null,
+                    'response' => null,
                 ],
             ],
             // Partial Report - classroom override
@@ -80,9 +78,7 @@ class ReportDeadlinesTest extends TestAbstract
                 [
                     'report'   => Carbon::parse($reportingDate1->toDateString(), $center->timezone)
                                         ->setTime(23, 59, 59),
-                    'response' => Carbon::parse($reportingDate1->toDateString(), $center->timezone)
-                                        ->addDay()
-                                        ->setTime(10, 0, 0),
+                    'response' => null,
                 ],
             ],
             // Partial Report - week override


### PR DESCRIPTION
During the last week of the quarter, regionals do not need to make sure preliminary report is accurate and will not reply back confirming a team is complete. That is done in person on Friday at the weekend.

Don't include that promise in the email sent out during the last week.