### PR TITLE
First week submission fixes, pt1:

### DIFF
--- a/src/app/Domain/ScoreboardGame.php
+++ b/src/app/Domain/ScoreboardGame.php
@@ -34,7 +34,7 @@ class ScoreboardGame
     ];
 
     public $key;
-    private $promise = 0;
+    private $promise = null;
     private $actual = null;
     private $originalPromise = null;
 

--- a/src/app/Domain/ScoreboardMultiWeek.php
+++ b/src/app/Domain/ScoreboardMultiWeek.php
@@ -18,7 +18,7 @@ class ScoreboardMultiWeek
         $result = new static();
         foreach ($data as $weekKey => $weekData) {
             $d = Carbon::createFromFormat('Y-m-d', $weekKey);
-            $week = $result->ensureWeek($weekKey);
+            $week = $result->ensureWeek($d);
             $week->parseArray($weekData);
         }
 

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -332,6 +332,24 @@ class Quarter extends Model
     }
 
     /**
+     * List all reporting dates in a center quarter
+     * @param  Center|null $center The center
+     * @return array               An array of Carbon objects being each reporting week in the quarter
+     */
+    public function listReportingDates(Center $center = null)
+    {
+        $output = [];
+        $d = $this->getFirstWeekDate($center)->copy();
+        $endDate = $this->getQuarterEndDate($center)->copy();
+        while ($d->lte($endDate)) {
+            $output[] = $d;
+            $d = $d->copy()->addWeek();
+        }
+
+        return $output;
+    }
+
+    /**
      * Set the region for this quarter instance
      *
      * Required before accessing regional quarter dates


### PR DESCRIPTION
* SubmissionCore lookups work even when we have no statsReport (first
  week of quarter)
- Scoreboard presents a valid blank scoreboard on week 1
- Added helpers for the first week report/quarter lookup