### PR TITLE
Add validator for course completion stats

### DIFF
--- a/src/app/Message.php
+++ b/src/app/Message.php
@@ -714,6 +714,22 @@ class Message
                 '%%reportingDate%%',
             ],
         ],
+        'IMPORTDOC_CAP_REG_CPC_REG_MISMATCH' => [
+            'type' => Message::WARNING,
+            'format' => 'CAP course completion registrations (%%coursRegistrations%%) is greater than the number of CPC registrations this week (%%cpcRegistrations%%). If this is accurate, please provide details explaining to your regional statistician.',
+            'arguments' => [
+                '%%coursRegistrations%%',
+                '%%cpcRegistrations%%',
+            ],
+        ],
+        'IMPORTDOC_CPC_REG_T1_APP_MISMATCH' => [
+            'type' => Message::WARNING,
+            'format' => 'CPC course completion registrations (%%coursRegistrations%%) is greater than the number of T1 applications registered this week (%%appRegistrations%%). If this is accurate, please provide details explaining to your regional statistician.',
+            'arguments' => [
+                '%%coursRegistrations%%',
+                '%%appRegistrations%%',
+            ],
+        ],
 
         // CenterStats Importer Errors
         'CENTERSTATS_WEEK_DATE_FORMAT_INVALID' => [

--- a/src/app/Validate/Relationships/CourseCompletionValidator.php
+++ b/src/app/Validate/Relationships/CourseCompletionValidator.php
@@ -1,0 +1,122 @@
+<?php
+namespace TmlpStats\Validate\Relationships;
+
+use TmlpStats as Models;
+use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
+use TmlpStats\Validate\ValidatorAbstract;
+
+class CourseCompletionValidator extends ValidatorAbstract
+{
+    protected $sheetId = ImportDocument::TAB_WEEKLY_STATS;
+
+    protected function validate($data)
+    {
+        if (!$this->validateCapCompletion($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateCpcCompletion($data)) {
+            $this->isValid = false;
+        }
+
+        return $this->isValid;
+    }
+
+    public function validateCapCompletion($data)
+    {
+        $isValid = true;
+
+        $lastWeekDate = $this->reportingDate->copy()->subWeek();
+
+        $coursesCompleted = array();
+
+        $courses = $data['commCourseInfo'];
+        $completionRegistrations = 0;
+        $cpcCurrentStandardStarts = 0;
+        $cpcQStartStandardStarts  = 0;
+        foreach ($courses as $course) {
+            if ($course['type'] == 'CAP'
+                && $course['startDate']->gt($lastWeekDate)
+                && $course['startDate']->lt($this->reportingDate)
+            ) {
+                $completionRegistrations += $course['registrations'];
+                $coursesCompleted[] = $course;
+            }
+            if ($course['type'] == 'CPC') {
+                $cpcCurrentStandardStarts += $course['currentStandardStarts'];
+                $cpcQStartStandardStarts += $course['quarterStartStandardStarts'];
+            }
+        }
+
+        if (!$coursesCompleted) {
+            return $isValid;
+        }
+
+        // Ignore reports from last quarter here because there is no "last week" value for
+        // the first week of the quarter.
+        $lastWeeksReport = Models\StatsReport::byCenter($this->center)
+            ->byQuarter($this->quarter)
+            ->reportingDate($lastWeekDate)
+            ->official()
+            ->first();
+
+        $lastWeeksCpc = 0;
+        if ($lastWeeksReport) {
+            $lastWeeksActuals = $lastWeeksReport->centerStatsData()
+                ->actual()
+                ->reportingDate($lastWeekDate)
+                ->first();
+
+            if ($lastWeeksActuals) {
+                $lastWeeksCpc = $lastWeeksActuals->cpc;
+            }
+        }
+
+        // Registrations from the last week
+        $cpcRegistrations = ($cpcCurrentStandardStarts - $cpcQStartStandardStarts) - $lastWeeksCpc;
+
+        if ($completionRegistrations > $cpcRegistrations) {
+            $this->addMessage('IMPORTDOC_CAP_REG_CPC_REG_MISMATCH', $completionRegistrations, $cpcRegistrations);
+        }
+
+        return $isValid;
+    }
+
+    public function validateCpcCompletion($data)
+    {
+        $isValid = true;
+
+        $lastWeekDate = $this->reportingDate->copy()->subWeek();
+
+        $courses = $data['commCourseInfo'];
+        $courseRegistrations = 0;
+        foreach ($courses as $course) {
+            if ($course['type'] == 'CPC'
+                && $course['startDate']->gt($lastWeekDate)
+                && $course['startDate']->lt($this->reportingDate)
+            ) {
+                $courseRegistrations += $course['registrations'];
+                $coursesCompleted[] = $course;
+            }
+        }
+
+        if (!$coursesCompleted) {
+            return $isValid;
+        }
+
+        $registrations = $data['tmlpRegistration'];
+        $appRegistrations = 0;
+        foreach ($registrations as $registration) {
+            if ($registration['incomingTeamYear'] == 1
+                && $registration['regDate']->gt($lastWeekDate)
+            ) {
+                $appRegistrations++;
+            }
+        }
+
+        if ($courseRegistrations > $appRegistrations) {
+            $this->addMessage('IMPORTDOC_CPC_REG_T1_APP_MISMATCH', $courseRegistrations, $appRegistrations);
+        }
+
+        return $isValid;
+    }
+}

--- a/src/app/Validate/ValidationManager.php
+++ b/src/app/Validate/ValidationManager.php
@@ -46,7 +46,7 @@ class ValidationManager
             }
         }
 
-        // These need needs the class list to
+        // These need only need one data group
         $teamMemberExistsChecks = [
             'contactInfoTeamMember' => 'contactInfo',
             'committedTeamMember'   => 'tmlpRegistration',
@@ -57,7 +57,8 @@ class ValidationManager
             }
         }
 
-        foreach (['teamExpansion', 'centerGames', 'statsReport'] as $type) {
+        // These need only need all the data groups
+        foreach (['teamExpansion', 'centerGames', 'courseCompletion', 'statsReport'] as $type) {
             $validator = ValidatorFactory::build($this->statsReport, $type);
             if (!$validator->run($data)) {
                 $isValid = false;

--- a/src/app/Validate/ValidatorFactory.php
+++ b/src/app/Validate/ValidatorFactory.php
@@ -29,6 +29,7 @@ class ValidatorFactory
             case 'duplicateTmlpRegistration':
             case 'teamExpansion':
             case 'centerGames':
+            case 'courseCompletion':
             case 'apiCenterGames':
                 $class = '\\TmlpStats\\Validate\\Relationships\\' . ucfirst($type) . 'Validator';
                 break;


### PR DESCRIPTION
WIP

This validator checks the course completion stats' registrations, and compares that against the actual number of new registrations that week.
- For CAP, it looks at the delta in CPC registrations that week
- For CPC, it looks at the number of T1 applications with registration dates after the course start date.

The resulting message is marked a warning since there are special cases where a difference is expected.

TODO: write unit tests for new validator
