### PR TITLE
Fix JS setup issue in new JQ variant of reports.

### DIFF
--- a/src/public/js/tmlpstats.js
+++ b/src/public/js/tmlpstats.js
@@ -21,8 +21,8 @@ function getErrorMessage(code) {
  *      en-US: 12/2/15
  *      en-UK: 2/12/15
  */
-function updateDates() {
-    $('span.date').each(function (index, dateElem) {
+function updateDates(context) {
+    $('span.date', context).each(function (index, dateElem) {
         var formatted = moment($(dateElem).data('date')).format('l');
         formatted = formatted.replace(/\d\d(\d\d)/, "$1");
         $(dateElem).text(formatted);
@@ -33,8 +33,9 @@ function updateDates() {
  * Initialize all uninitialized datatables
  * @param options
  * @param tableClass
+ * @param context: If specified, must be a DOM context for jquery to work with.
  */
-function initDataTables(options, tableClass) {
+function initDataTables(options, tableClass, context) {
     if (!options) {
         tableClass = 'want-datatable';
         options = {
@@ -45,7 +46,7 @@ function initDataTables(options, tableClass) {
     // document.ready may fire immediately depending on the current state of the DOM
     // We use the want-datatable class as a flip to avoid continuously binding tables
     $(document).ready(function() {
-        $('table.' + tableClass).each(function() {
+        $('table.' + tableClass, context).each(function() {
             var table = $(this);
             table.removeClass(tableClass).dataTable(options);
         })

--- a/src/resources/assets/js/classic/reports-view.js
+++ b/src/resources/assets/js/classic/reports-view.js
@@ -73,7 +73,10 @@ window.showReportView = function(config) {
             pages.forEach((page) => {
                 debug('loaded page', page)
                 loaded[page] = true
-                $(`#${page}-content`).html(data.pages[page])
+                const container = target.find(`#${page}-content`)
+                container.html(data.pages[page])
+                window.updateDates(container)
+                window.initDataTables(undefined, undefined, container)
             })
 
             setTimeout(loadNext, 200)


### PR DESCRIPTION
Also do a little bit of wizardry to speed up the DOM selectors a tad.