### PR TITLE
Add new Courses Summary report

### DIFF
--- a/src/app/Http/Controllers/Encapsulate/GlobalReportCoursesData.php
+++ b/src/app/Http/Controllers/Encapsulate/GlobalReportCoursesData.php
@@ -82,6 +82,25 @@ class GlobalReportCoursesData
         return $targetCourses;
     }
 
+    protected function getCoursesSummary($coursesData, Models\GlobalReport $globalReport, Models\Region $region)
+    {
+        $a = new Arrangements\CoursesWithEffectiveness([
+            'courses' => $coursesData,
+            'reportingDate' => $globalReport->reportingDate,
+            'includeTotals' => true,
+            'combineCompleted' => true,
+        ]);
+        $arrangedData = $a->compose();
+
+        $type = 'summary';
+        $reportData = [
+            'CAP' => $arrangedData['reportData']['CAP']['totals'],
+            'CPC' => $arrangedData['reportData']['CPC']['totals'],
+        ];
+
+        return view('globalreports.details.courses', compact('reportData', 'type'));
+    }
+
     /** CLASSIC METHOD - getCoursesAll */
     public function getCoursesAllClassic(Models\GlobalReport $globalReport, Models\Region $region)
     {
@@ -91,6 +110,7 @@ class GlobalReportCoursesData
             'coursesupcoming',
             'coursescompleted',
             'coursesguestgames',
+            'coursessummary',
         ];
 
         $responseData = [];
@@ -150,6 +170,9 @@ class GlobalReportCoursesData
                 $targetData = $this->getCoursesGuestGames($data, $globalReport, $region);
                 $type = 'guests';
                 break;
+            case 'coursessummary':
+            case 'CoursesSummary':
+                return $this->getCoursesSummary($data, $globalReport, $region);
             default:
                 throw new \Exception("Unkown page $page");
         }

--- a/src/app/Http/Controllers/GlobalReportController.php
+++ b/src/app/Http/Controllers/GlobalReportController.php
@@ -244,6 +244,7 @@ class GlobalReportController extends ReportDispatchAbstractController
             case 'coursesupcoming':
             case 'coursescompleted':
             case 'coursesguestgames':
+            case 'coursessummary':
                 $response = $this->coursesData($globalReport, $region)->getOne($report);
                 break;
             case 'coursesall':
@@ -1019,6 +1020,12 @@ class GlobalReportController extends ReportDispatchAbstractController
     protected function getCoursesGuestGames($globalReport, $region)
     {
         return $this->coursesData($globalReport, $region)->getOne('CoursesGuestGames');
+    }
+
+    // Get report Summary
+    protected function getCoursesSummary($globalReport, $region)
+    {
+        return $this->coursesData($globalReport, $region)->getOne('CoursesSummary');
     }
 
     public function getWithdrawReport(Models\GlobalReport $globalReport, Models\Region $region)

--- a/src/app/Http/Controllers/Traits/GlobalReportDispatch.php
+++ b/src/app/Http/Controllers/Traits/GlobalReportDispatch.php
@@ -101,6 +101,10 @@ trait GlobalReportDispatch {
             case 'coursesguestgames':
                 return 'getCoursesGuestGames';
                 break;
+            case 'CoursesSummary':
+            case 'coursessummary':
+                return 'getCoursesSummary';
+                break;
             case 'TeamMemberStatusCtw':
             case 'teammemberstatusctw':
                 return 'getTeamMemberStatusCtw';
@@ -187,6 +191,9 @@ trait GlobalReportDispatch {
 
     // Get report Guest Games
     protected abstract function getCoursesGuestGames();
+
+    // Get report Summary
+    protected abstract function getCoursesSummary();
 
     // Get report CTW
     protected abstract function getTeamMemberStatusCtw();

--- a/src/app/Reports/Arrangements/CoursesWithEffectiveness.php
+++ b/src/app/Reports/Arrangements/CoursesWithEffectiveness.php
@@ -7,8 +7,40 @@ class CoursesWithEffectiveness extends BaseArrangement
      */
     public function build($data)
     {
-        $courses       = $data['courses'];
+        $courses = $data['courses'];
         $reportingDate = $data['reportingDate'];
+        $includeTotals = isset($data['includeTotals']) && $data['includeTotals'];
+        $combineCompleted = isset($data['combineCompleted']) && $data['combineCompleted'];
+
+        $copyFields = [
+            'courseId',
+            'quarterStartTer',
+            'quarterStartStandardStarts',
+            'quarterStartXfer',
+            'currentTer',
+            'currentStandardStarts',
+            'currentXfer',
+            'completedStandardStarts',
+            'potentials',
+            'registrations',
+            'guestsPromised',
+            'guestsInvited',
+            'guestsConfirmed',
+            'guestsAttended',
+        ];
+
+        $totals = [
+            'CAP' => [
+                'open' => array_fill_keys($copyFields, 0),
+                'closed' => array_fill_keys($copyFields, 0),
+                'all' => array_fill_keys($copyFields, 0),
+            ],
+            'CPC' => [
+                'open' => array_fill_keys($copyFields, 0),
+                'closed' => array_fill_keys($copyFields, 0),
+                'all' => array_fill_keys($copyFields, 0),
+            ],
+        ];
 
         $reportData = [];
         foreach ($courses as $courseData) {
@@ -22,45 +54,80 @@ class CoursesWithEffectiveness extends BaseArrangement
                 'type'       => $type,
             ];
 
-            $copyFields = [
-                'courseId',
-                'quarterStartTer',
-                'quarterStartStandardStarts',
-                'quarterStartXfer',
-                'currentTer',
-                'currentStandardStarts',
-                'currentXfer',
-                'completedStandardStarts',
-                'potentials',
-                'registrations',
-                'guestsPromised',
-                'guestsInvited',
-                'guestsConfirmed',
-                'guestsAttended',
-            ];
+            $isComplete = $course['startDate']->lt($reportingDate);
 
             foreach ($copyFields as $field) {
                 $course[$field] = $courseData->$field;
+
+                if ($includeTotals) {
+                    $state = $isComplete ? 'closed' : 'open';
+
+                    $totals[$type][$state][$field] += $courseData->$field;
+                    $totals[$type]['all'][$field] += $courseData->$field;
+                }
             }
 
-            $course['completionStats']['registrationFulfillment']   = $courseData->currentTer
-                ? round(($courseData->currentStandardStarts / $courseData->currentTer) * 100)
-                : 0;
+            $course['completionStats'] = $this->calculateEffectiveness($course, $isComplete);
 
-            if ($course['startDate']->lt($reportingDate)) {
-                $course['completionStats']['registrationEffectiveness'] = $courseData->potentials
-                    ? round(($courseData->registrations / $courseData->potentials) * 100)
-                    : 0;
-                if ($courseData->guestsPromised) {
-                    $course['completionStats']['guestsGameEffectiveness'] = round(($courseData->guestsAttended / $courseData->guestsPromised) * 100);
-                }
-
+            if ($isComplete && !$combineCompleted) {
                 $type = 'completed';
             }
 
             $reportData[$type][] = $course;
         }
 
+        if ($includeTotals) {
+            foreach (['CAP', 'CPC'] as $type) {
+                foreach (['open', 'closed', 'all'] as $state) {
+                    $totals[$type][$state] = array_merge(
+                        $totals[$type][$state],
+                        $this->calculateEffectiveness($totals[$type][$state], $state !== 'open')
+                    );
+                }
+            }
+
+            $reportData['CAP']['totals'] = $totals['CAP'];
+            $reportData['CPC']['totals'] = $totals['CPC'];
+        }
+
         return compact('reportData');
+    }
+
+    protected function calculateEffectiveness($courseData, $isComplete)
+    {
+        $result = [
+            'registrationFulfillment' => 0,
+            'registrationEffectiveness' => 0,
+            'guestsGameEffectiveness' => 0,
+        ];
+
+        $result['registrationFulfillment'] = $this->getPercent(
+            $courseData['currentStandardStarts'],
+            $courseData['currentTer']
+        );
+
+        if ($isComplete) {
+            $result['registrationEffectiveness'] = $this->getPercent(
+                $courseData['registrations'],
+                $courseData['potentials']
+            );
+            if ($courseData['guestsPromised']) {
+                $result['guestsGameEffectiveness'] = $this->getPercent(
+                    $courseData['guestsAttended'],
+                    $courseData['guestsPromised']
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    protected function getPercent($actual, $promise)
+    {
+        if (!$promise) {
+            return 0;
+        }
+
+        return round(($actual / $promise) * 100);
     }
 }

--- a/src/config/reports.yml
+++ b/src/config/reports.yml
@@ -518,6 +518,8 @@ reportMeta:
             name: Completed
           CoursesGuestGames:
             name: Guest Games
+          CoursesSummary:
+            name: Summary
 
       TeamMemberStatusGroup:
         type: grouping

--- a/src/resources/assets/js/classic/reports-generated.js
+++ b/src/resources/assets/js/classic/reports-generated.js
@@ -170,9 +170,15 @@ const GlobalReport = {
             "type": "report",
             "name": "Guest Games"
         },
+        "CoursesSummary": {
+            "id": "CoursesSummary",
+            "n": 22,
+            "type": "report",
+            "name": "Summary"
+        },
         "CoursesGroup": {
             "id": "CoursesGroup",
-            "n": 22,
+            "n": 23,
             "type": "grouping",
             "name": "Courses",
             "children": [
@@ -180,30 +186,31 @@ const GlobalReport = {
                 "CoursesNextMonth",
                 "CoursesUpcoming",
                 "CoursesCompleted",
-                "CoursesGuestGames"
+                "CoursesGuestGames",
+                "CoursesSummary"
             ]
         },
         "TeamMemberStatusCtw": {
             "id": "TeamMemberStatusCtw",
-            "n": 23,
+            "n": 24,
             "type": "report",
             "name": "CTW"
         },
         "TeamMemberStatusTransfer": {
             "id": "TeamMemberStatusTransfer",
-            "n": 24,
+            "n": 25,
             "type": "report",
             "name": "Transfers"
         },
         "TeamMemberStatusWithdrawn": {
             "id": "TeamMemberStatusWithdrawn",
-            "n": 25,
+            "n": 26,
             "type": "report",
             "name": "Withdrawn"
         },
         "TeamMemberStatusGroup": {
             "id": "TeamMemberStatusGroup",
-            "n": 26,
+            "n": 27,
             "type": "grouping",
             "name": "Team Members",
             "children": [
@@ -214,26 +221,26 @@ const GlobalReport = {
         },
         "TdoSummary": {
             "id": "TdoSummary",
-            "n": 27,
+            "n": 28,
             "type": "report",
             "name": "Training & Development",
             "shortName": "TDO"
         },
         "TeamMemberStatusPotentialsOverview": {
             "id": "TeamMemberStatusPotentialsOverview",
-            "n": 28,
+            "n": 29,
             "type": "report",
             "name": "Overview"
         },
         "TeamMemberStatusPotentials": {
             "id": "TeamMemberStatusPotentials",
-            "n": 29,
+            "n": 30,
             "type": "report",
             "name": "Details"
         },
         "PotentialsGroup": {
             "id": "PotentialsGroup",
-            "n": 30,
+            "n": 31,
             "type": "grouping",
             "name": "Potentials",
             "children": [
@@ -243,7 +250,7 @@ const GlobalReport = {
         },
         "WithdrawReport": {
             "id": "WithdrawReport",
-            "n": 31,
+            "n": 32,
             "type": "report",
             "name": "Withdraws"
         }

--- a/src/resources/views/globalreports/details/courses.blade.php
+++ b/src/resources/views/globalreports/details/courses.blade.php
@@ -1,6 +1,14 @@
 <div class="table-responsive">
     <br />
-    @if ($type == 'guests')
+    @if ($type == 'summary')
+        @forelse ($reportData as $courseType => $coursesData)
+            <h4>{{ $courseType }}</h4>
+            @include('reports.courses.summary', compact('coursesData'))
+            <br />
+        @empty
+            <p>No courses available.</p>
+        @endforelse
+    @elseif ($type == 'guests')
         @if (count($reportData) > 0)
             @include('reports.courses.guests', ['coursesData' => $reportData])
         @else

--- a/src/resources/views/reports/courses/summary.blade.php
+++ b/src/resources/views/reports/courses/summary.blade.php
@@ -1,0 +1,57 @@
+<table class="table table-condensed table-striped table-hover" style="width: 100%;">
+    <thead>
+        <tr>
+            <th>&nbsp;</th>
+            <th colspan="2" class="data-point border-left">
+                Starting
+            </th>
+            <th colspan="3" class="data-point border-left">
+                Current
+            </th>
+            <th colspan="4" class="data-point border-left">
+                Completion
+            </th>
+            <th colspan="5" class="data-point border-left">
+                Guest Game
+            </th>
+        </tr>
+        <tr>
+            <th class="data-point">&nbsp;</th>
+            <th class="data-point border-left" title="Total Ever Registered">TER</th>
+            <th class="data-point" title="Standard Starts">SS</th>
+            <th class="data-point border-left" title="Total Ever Registered">TER</th>
+            <th class="data-point" title=" title="Standard Starts">SS</th>
+            <th class="data-point border-left">Reg Fulfillment</th>
+            <th class="data-point border-left" title="Standard Starts that completed course">SS Completed</th>
+            <th class="data-point">Potentials</th>
+            <th class="data-point">Registrations</th>
+            <th class="data-point border-left">Reg Effectiveness</th>
+            <th class="data-point border-left">Promised</th>
+            <th class="data-point">Invited</th>
+            <th class="data-point">Confirmed</th>
+            <th class="data-point">Attended</th>
+            <th class="data-point border-left">Guests Effectiveness</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach ($coursesData as $state => $courseData)
+        <tr>
+            <td class="data-point">{{ ucfirst($state) }} Courses</td>
+            <td class="data-point border-left">{{ $courseData['quarterStartTer'] }}</td>
+            <td class="data-point">{{ $courseData['quarterStartStandardStarts'] }}</td>
+            <td class="data-point border-left">{{ $courseData['currentTer'] }}</td>
+            <td class="data-point">{{ $courseData['currentStandardStarts'] }}</td>
+            <td class="data-point border-left">{{ $courseData['registrationFulfillment'] }}%</td>
+            <td class="data-point border-left">{{ $state == 'open' ? '-' : $courseData['completedStandardStarts'] }}</td>
+            <td class="data-point">{{ $state == 'open' ? '-' : $courseData['potentials'] }}</td>
+            <td class="data-point">{{ $state == 'open' ? '-' : $courseData['registrations'] }}</td>
+            <td class="data-point border-left">{{ $state == 'open' ? '-' : $courseData['registrationEffectiveness'] . '%' }}</td>
+            <td class="data-point border-left">{{ $courseData['guestsPromised'] }}</td>
+            <td class="data-point">{{ $courseData['guestsInvited'] }}</td>
+            <td class="data-point">{{ $courseData['guestsConfirmed'] }}</td>
+            <td class="data-point">{{ $courseData['guestsAttended'] }}</td>
+            <td class="data-point border-left">{{ $courseData['guestsGameEffectiveness'] }}%</td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>


### PR DESCRIPTION
Add new report to summarize courses for a region. This is equivalent to the summary on the top of the regional report's CAP Courses/CPC Courses tabs.