### PR TITLE
Add next and back buttons on center report page

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -151,14 +151,14 @@ class StatsReportController extends ReportDispatchAbstractController
             ->first();
 
         $lastReport = null;
-        if ($lastCenter) {
+        if ($lastCenter && Gate::allows('showReportNavLinks', Models\StatsReport::class)) {
             $lastReport = $globalReport->statsReports()
                 ->byCenter($lastCenter)
                 ->first();
         }
 
         $nextReport = null;
-        if ($nextCenter) {
+        if ($nextCenter && Gate::allows('showReportNavLinks', Models\StatsReport::class)) {
             $nextReport = $globalReport->statsReports()
                 ->byCenter($nextCenter)
                 ->first();

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -109,69 +109,60 @@ class StatsReportController extends ReportDispatchAbstractController
     /**
      * Display the specified resource.
      *
-     * @param  int $id
-     *
+     * @param  Request $request
+     * @param  integer $id
      * @return Response
      */
     public function show(Request $request, $id)
     {
         $statsReport = Models\StatsReport::findOrFail($id);
+
+        $this->authorize('read', $statsReport);
+
         $this->context->setCenter($statsReport->center);
         $this->context->setReportingDate($statsReport->reportingDate);
         $centerReportingDate = Encapsulations\CenterReportingDate::ensure();
         $this->context->setDateSelectAction('ReportsController@getCenterReport', [
             'abbr' => $statsReport->center->abbrLower(),
         ]);
-        $this->authorize('read', $statsReport);
 
-        $sheetUrl = '';
-        $globalReport = null;
-        $center = $statsReport->center;
 
         $sheetPath = XlsxArchiver::getInstance()->getSheetPath($statsReport);
 
+        $sheetUrl = '';
         if ($sheetPath) {
             $sheetUrl = $sheetPath ? url("/statsreports/{$statsReport->id}/download") : null;
         }
 
-        $quarterStartDate = $statsReport->quarter->getQuarterStartDate($center);
-        $quarterEndDate = $statsReport->quarter->getQuarterEndDate($center);
-
-        // Other Stats Reports
-        $otherStatsReports = [];
-        $searchWeek = $quarterEndDate->copy();
-
-        while ($searchWeek->gte($quarterStartDate)) {
-            $globalReport = Models\GlobalReport::reportingDate($searchWeek)->first();
-            if ($globalReport) {
-                $report = $globalReport->statsReports()->byCenter($center)->first();
-                if ($report) {
-                    $otherStatsReports[$report->id] = $report->reportingDate->format('M d, Y');
-                }
-            }
-            $searchWeek->subWeek();
-        }
-
-        // Only show last quarter's completion report on the first week
-        if ($statsReport->reportingDate->diffInWeeks($quarterStartDate) > 1) {
-            array_pop($otherStatsReports);
-        }
-
-        // When showing last quarter's data, make sure we also show this week's report
-        if ($quarterEndDate->lt(Carbon::now())) {
-            $firstWeek = $quarterEndDate->copy();
-            $firstWeek->addWeek();
-
-            $globalReport = Models\GlobalReport::reportingDate($firstWeek)->first();
-            if ($globalReport) {
-                $report = $globalReport->statsReports()->byCenter($center)->first();
-                if ($report) {
-                    $otherStatsReports = [$report->id => $report->reportingDate->format('M d, Y')] + $otherStatsReports;
-                }
-            }
-        }
-
+        $center = $statsReport->center;
         $globalReport = Models\GlobalReport::reportingDate($statsReport->reportingDate)->first();
+        $globalRegion = $center->region->getParentGlobalRegion();
+
+        $nextCenter = Models\Center::active()
+            ->byRegion($globalRegion)
+            ->where('name', '>', $center->name)
+            ->orderBy('name')
+            ->first();
+
+        $lastCenter = Models\Center::active()
+            ->byRegion($globalRegion)
+            ->where('name', '<', $center->name)
+            ->orderBy('name')
+            ->first();
+
+        $lastReport = null;
+        if ($lastCenter) {
+            $lastReport = $globalReport->statsReports()
+                ->byCenter($lastCenter)
+                ->first();
+        }
+
+        $nextReport = null;
+        if ($nextCenter) {
+            $nextReport = $globalReport->statsReports()
+                ->byCenter($nextCenter)
+                ->first();
+        }
 
         $reportToken = null;
         if (Gate::allows('readLink', Models\ReportToken::class)) {
@@ -182,9 +173,10 @@ class StatsReportController extends ReportDispatchAbstractController
 
         return view('statsreports.show', compact(
             'statsReport',
+            'lastReport',
+            'nextReport',
             'centerReportingDate',
             'globalReport',
-            'otherStatsReports',
             'sheetUrl',
             'reportToken',
             'showNavCenterSelect'

--- a/src/app/Policies/StatsReportPolicy.php
+++ b/src/app/Policies/StatsReportPolicy.php
@@ -140,4 +140,9 @@ class StatsReportPolicy extends Policy
 
         return true;
     }
+
+    public function showReportNavLinks(User $user)
+    {
+        return $user->hasRole('globalStatistician');
+    }
 }

--- a/src/public/css/tmlpstats.css
+++ b/src/public/css/tmlpstats.css
@@ -9,6 +9,10 @@
 
     .container-fluid {
     }
+
+    .hide-mobile {
+        display: none;
+    }
 }
 
 @media (min-width: 992px) {

--- a/src/resources/views/home.blade.php
+++ b/src/resources/views/home.blade.php
@@ -15,12 +15,10 @@
                     <thead>
                     <tr>
                         <th>Center</th>
-                        <th style="text-align: center">Region</th>
                         <th style="text-align: center">Submitted</th>
                         <th>Rating</th>
                         <th>Submitted</th>
                         <th>Submitted By</th>
-                        <th>&nbsp;</th>
                         <th>&nbsp;</th>
                     </tr>
                     </thead>
@@ -36,20 +34,12 @@
                                     {{ $center['name'] }}
                                 @endif
                             </td>
-                            <td style="text-align: center">{{ $center['localRegion'] ?: '' }}</td>
                             <td style="text-align: center">
                                 <span class="glyphicon {{ $center['submitted'] ? 'glyphicon-ok' : 'glyphicon-remove' }}"></span>
                             </td>
                             <td>{{ $center['rating'] }}</td>
                             <td>{{ $center['updatedAt'] }}</td>
                             <td>{{ $center['updatedBy'] }}</td>
-                            <td style="text-align: center">
-                                @if ($center['reportUrl'])
-                                    <a href="{{ $center['reportUrl'] }}" class="view" title="View" style="color: black">
-                                        <span class="glyphicon glyphicon-eye-open"></span>
-                                    </a>
-                                @endif
-                            </td>
                             <td style="text-align: center">
                                 @if ($center['sheet'])
                                     <a href="{{ $center['sheet'] }}" title="Download" style="color: black">

--- a/src/resources/views/statsreports/show.blade.php
+++ b/src/resources/views/statsreports/show.blade.php
@@ -19,7 +19,7 @@ $nextQtrAccountabilities = $centerReportingDate->canShowNextQtrAccountabilities(
         </div>
         <div class="col-sm-1 hide-mobile" style="text-align: right">
             @if (isset($lastReport))
-                <a href="{{ url('/statsreports/' . $lastReport->id) }}"><< Back</a><br/><br/>
+                <a href="{{ url('/statsreports/' . $lastReport->id) }}"><< Last</a><br/><br/>
             @endif
         </div>
         <div class="col-sm-1 hide-mobile">

--- a/src/resources/views/statsreports/show.blade.php
+++ b/src/resources/views/statsreports/show.blade.php
@@ -13,7 +13,21 @@ $nextQtrAccountabilities = $centerReportingDate->canShowNextQtrAccountabilities(
         @endif
     </h2>
     @can ('index', TmlpStats\StatsReport::class)
-    <a href="{{ url('/home') }}"><< See All</a><br/><br/>
+    <div class="row">
+        <div class="col-sm-10">
+            <a href="{{ url('/home') }}"><< See All</a><br/><br/>
+        </div>
+        <div class="col-sm-1 hide-mobile" style="text-align: right">
+            @if (isset($lastReport))
+                <a href="{{ url('/statsreports/' . $lastReport->id) }}"><< Back</a><br/><br/>
+            @endif
+        </div>
+        <div class="col-sm-1 hide-mobile">
+            @if (isset($nextReport))
+                <a href="{{ url('/statsreports/' . $nextReport->id) }}">Next >></a><br/><br/>
+            @endif
+        </div>
+    </div>
     @endcan
     @if ($reportToken)
         <div class="modal fade" id="reportLinkModel" tabindex="-1" role="dialog" aria-labelledby="reportLinkModelLabel">


### PR DESCRIPTION
- On regional's home page, remove eyeball link and Region since they are redundant
- On stats reports page, remove unused $otherStatsReports data (I removed it from the display long ago and never removed the data)
- On stats reports page, add links to go to next and last reports alphabetically