### PR TITLE
Fix date handling for some reports when at the weekend

### DIFF
--- a/src/app/Api/Context.php
+++ b/src/app/Api/Context.php
@@ -175,12 +175,11 @@ class Context
      */
     public function getReportingDate()
     {
-        $reportingDate = $this->reportingDate;
-        if (!$reportingDate) {
-            $reportingDate = App::make(Controller::class)->getReportingDate($this->request);
+        if ($this->reportingDate) {
+            return $this->reportingDate;
         }
 
-        return $reportingDate;
+        return App::make(Controller::class)->getReportingDate();
     }
 
     /**

--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -1,6 +1,7 @@
 <?php
 namespace TmlpStats\Http\Controllers;
 
+use App;
 use Auth;
 use Carbon\Carbon;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -8,6 +9,7 @@ use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Session;
+use TmlpStats\Api;
 use TmlpStats\Center;
 use TmlpStats\Import\ImportManager;
 use TmlpStats\Region;
@@ -17,6 +19,7 @@ class Controller extends BaseController
 {
     use ValidatesRequests, AuthorizesRequests;
 
+    protected $context;
     protected $region = null;
     protected $center = null;
     protected $reportingDate = null;
@@ -27,6 +30,7 @@ class Controller extends BaseController
     public function __construct()
     {
         $this->middleware('auth');
+        $this->context = App::make(Api\Context::class);
     }
 
     /**
@@ -98,42 +102,29 @@ class Controller extends BaseController
         return $center;
     }
 
-    public function getReportingDate(Request $request, $reportingDates = [])
+    public function getReportingDate()
     {
         $reportingDate = null;
         $reportingDateString = '';
 
-        // First try to get the date from the request
-        if ($request->has('reportingDate') && preg_match('/^\d\d\d\d-\d\d-\d\d$/', $request->get('reportingDate'))) {
-            $reportingDateString = $request->get('reportingDate');
-        }
-
         // Then try to pull it from the session if it's there
-        if (!$reportingDateString && Session::has('viewReportingDate')) {
+        if (Session::has('viewReportingDate')) {
             $reportingDateString = Session::get('viewReportingDate');
         }
 
         // If we have a reportToken, use the reportingDate from that report
         if (!$reportingDateString && Session::has('reportTokenId')) {
             $reportToken = ReportToken::find(Session::get('reportTokenId'));
-            $report = $reportToken
-            ? $reportToken->getReport()
-            : null;
 
-            if ($report) {
+            if ($reportToken) {
+                $report = $reportToken->getReport();
                 $reportingDateString = $report->reportingDate->toDateString();
                 Session::set('viewReportingDate', $reportingDateString);
             }
         }
 
         // Finally, if we don't have it yet make an educated guess
-        if ($reportingDates) {
-            if (in_array($reportingDateString, $reportingDates)) {
-                $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString);
-            } else {
-                $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDates[0]);
-            }
-        } else if ($reportingDateString) {
+        if ($reportingDateString) {
             $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString);
         } else {
             $reportingDate = ImportManager::getExpectedReportDate();

--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -107,7 +107,7 @@ class Controller extends BaseController
         $reportingDate = null;
         $reportingDateString = '';
 
-        // Then try to pull it from the session if it's there
+        // First check if the date is already cached in the session
         if (Session::has('viewReportingDate')) {
             $reportingDateString = Session::get('viewReportingDate');
         }
@@ -123,7 +123,7 @@ class Controller extends BaseController
             }
         }
 
-        // Finally, if we don't have it yet make an educated guess
+        // Finally, create date or get reasonable default
         if ($reportingDateString) {
             $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString);
         } else {

--- a/src/app/Http/Controllers/GlobalReportController.php
+++ b/src/app/Http/Controllers/GlobalReportController.php
@@ -202,7 +202,6 @@ class GlobalReportController extends ReportDispatchAbstractController
         $region = array_get($extra, 'region', $this->context->getRegion(true));
         $this->context->setRegion($region);
         $this->context->setReportingDate($globalReport->reportingDate);
-        $this->setReportingDate($globalReport->reportingDate);
 
         $response = null;
         switch ($report) {

--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -93,7 +93,19 @@ class HomeController extends Controller
             $reportingDates[$dateString] = $report->reportingDate->format('F j, Y');
         }
 
-        $reportingDate = $this->getReportingDate($request, array_keys($reportingDates));
+        // Find the best reportingDate
+        $reportingDateString = '';
+        if (Session::has('viewReportingDate')) {
+            $reportingDateString = Session::get('viewReportingDate');
+        }
+
+        if (!$reportingDateString || !isset($reportingDates[$reportingDateString])) {
+            $dateStrings = array_keys($reportingDates);
+            $reportingDateString = $dateStrings[0];
+        }
+
+        $reportingDate = Carbon::createFromFormat('Y-m-d', $reportingDateString)->startOfDay();
+
         $centers = Center::active()
             ->byRegion($region)
             ->orderBy('name', 'asc')

--- a/src/app/Http/Controllers/ReportDispatchAbstractController.php
+++ b/src/app/Http/Controllers/ReportDispatchAbstractController.php
@@ -4,7 +4,6 @@ namespace TmlpStats\Http\Controllers;
 use Cache;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
-use TmlpStats\Util;
 
 abstract class ReportDispatchAbstractController extends Controller
 {
@@ -83,7 +82,7 @@ abstract class ReportDispatchAbstractController extends Controller
 
         $this->authorizeReport($model, $report);
 
-        Util::setReportDate($model->reportingDate);
+        $this->context->setReportingDate($model->reportingDate);
 
         $response = null;
 

--- a/src/app/Http/Controllers/ReportsController.php
+++ b/src/app/Http/Controllers/ReportsController.php
@@ -237,7 +237,7 @@ class ReportsController extends Controller
         // even if there hasn't been a report created yet
         $globalReport = null;
         if (!$reportingDate) {
-            $reportingDate = $this->getReportingDate($request);
+            $reportingDate = $this->getReportingDate();
 
             $globalReport = GlobalReport::reportingDate($reportingDate)->first();
             if (!$globalReport) {
@@ -279,7 +279,7 @@ class ReportsController extends Controller
     public function mobileDash(Request $request, $abbr)
     {
         $center = Center::abbreviation($abbr)->firstOrFail();
-        $reportingDate = $this->getReportingDate($request);
+        $reportingDate = $this->getReportingDate();
 
         $this->setCenter($center);
 

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -313,7 +313,6 @@ class StatsReportController extends ReportDispatchAbstractController
     {
         $this->setCenter($statsReport->center);
         $this->context->setCenter($statsReport->center);
-        $this->setReportingDate($statsReport->reportingDate);
         $this->context->setReportingDate($statsReport->reportingDate);
 
         if (!$statsReport->isValidated() && $report != 'results') {

--- a/src/app/Util.php
+++ b/src/app/Util.php
@@ -1,11 +1,13 @@
 <?php
 namespace TmlpStats;
 
+use App;
 use Cache;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Log;
 use Exception;
+use Log;
 use Session;
+use TmlpStats\Api;
 use stdClass;
 
 class Util
@@ -140,20 +142,13 @@ class Util
     }
 
     /**
-     * Assumed report date
-     *
-     * @var null|Carbon
-     */
-    protected static $reportDate = null;
-
-    /**
      * Set the report date
      *
      * @param Carbon $date
      */
     public static function setReportDate(Carbon $date)
     {
-        static::$reportDate = $date;
+        App::make(Api\Context::class)->setReportingDate($date);
     }
 
     /**
@@ -163,7 +158,7 @@ class Util
      */
     public static function getReportDate()
     {
-        return static::$reportDate ?: Carbon::now()->startOfDay();
+        return App::make(Api\Context::class)->getReportingDate();
     }
 
     /**

--- a/src/resources/views/template.blade.php
+++ b/src/resources/views/template.blade.php
@@ -5,7 +5,7 @@ if (!isset($skip_navbar)) {
 
 $center = App::make(TmlpStats\Http\Controllers\Controller::class)->getCenter(Request::instance());
 $region = App::make(TmlpStats\Http\Controllers\Controller::class)->getRegion(Request::instance());
-$reportingDate = App::make(TmlpStats\Http\Controllers\Controller::class)->getReportingDate(Request::instance());
+$reportingDate = App::make(TmlpStats\Http\Controllers\Controller::class)->getReportingDate();
 
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
The potential reports (and possibly others) were not reporting accurate results at the weekend because they rely on the current date to determine the quarter. At the weekend, the current date give the new quarter, but that's not what the report advertises to show.

Fixed by switching Util::getReportDate and Util::setReportDate to use Context methods.