### PR TITLE
Fix a few reports related to team members at weekend

### DIFF
--- a/src/app/Http/Controllers/Encapsulate/GlobalReportTeamMembersData.php
+++ b/src/app/Http/Controllers/Encapsulate/GlobalReportTeamMembersData.php
@@ -201,22 +201,23 @@ class GlobalReportTeamMembersData
             $potentials = $data['reportData']['t2Potential'];
             foreach ($potentials as $member) {
                 foreach ($registrations as $registration) {
-                    if ($registration->teamYear == 2
-                        && !$registration->isWithdrawn()
-                        && $registration->center->id == $member->center->id
+                    if ($registration->teamYear != 2
+                        || $registration->xferOut
+                        || $registration->isWithdrawn()
+                        || $registration->center->id != $member->center->id
                     ) {
-                        if ($member->teamMember->personId == $registration->registration->personId) {
-                            $potentialsThatRegistered[$member->teamMember->personId] = $registration;
-                            break;
-                        }
+                        continue;
+                    }
+
+                    if ($member->teamMember->personId == $registration->registration->personId) {
+                        $potentialsThatRegistered[$member->teamMember->personId] = $registration;
+                        break;
                     }
                 }
             }
         }
 
-        $potentialsData = $this->potentialsData = array_merge($data, ['registrations' => $potentialsThatRegistered]);
-
-        return $potentialsData;
+        return $this->potentialsData = array_merge($data, ['registrations' => $potentialsThatRegistered]);
     }
 
 }

--- a/src/app/Http/Controllers/ReportDispatchAbstractController.php
+++ b/src/app/Http/Controllers/ReportDispatchAbstractController.php
@@ -4,6 +4,7 @@ namespace TmlpStats\Http\Controllers;
 use Cache;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
+use TmlpStats\Util;
 
 abstract class ReportDispatchAbstractController extends Controller
 {

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -728,7 +728,10 @@ class StatsReportController extends ReportDispatchAbstractController
             }
         }
 
-        $a = new Arrangements\TeamMembersByQuarter(['teamMembersData' => $teamMembers]);
+        $a = new Arrangements\TeamMembersByQuarter([
+            'teamMembersData' => $teamMembers,
+            'includeXferAsWithdrawn' => true,
+        ]);
         $teamMembers = $a->compose();
         $teamMembers = $teamMembers['reportData'];
 

--- a/src/app/Reports/Arrangements/TeamMembersByQuarter.php
+++ b/src/app/Reports/Arrangements/TeamMembersByQuarter.php
@@ -8,7 +8,7 @@ class TeamMembersByQuarter extends BaseArrangement
     public function build($data)
     {
         $teamMembersData = $data['teamMembersData'];
-        $includeXferAsWithdrawn = $data['includeXferAsWithdrawn'];
+        $includeXferAsWithdrawn = array_get($data, 'includeXferAsWithdrawn', false);
 
         $reportData = [
             'team1'     => [],

--- a/src/app/Reports/Arrangements/TeamMembersByQuarter.php
+++ b/src/app/Reports/Arrangements/TeamMembersByQuarter.php
@@ -8,6 +8,7 @@ class TeamMembersByQuarter extends BaseArrangement
     public function build($data)
     {
         $teamMembersData = $data['teamMembersData'];
+        $includeXferAsWithdrawn = $data['includeXferAsWithdrawn'];
 
         $reportData = [
             'team1'     => [],
@@ -15,13 +16,16 @@ class TeamMembersByQuarter extends BaseArrangement
             'withdrawn' => [],
         ];
 
-        foreach ($teamMembersData as $data) {
+        foreach ($teamMembersData as $memberData) {
 
-            $index = $data->withdrawCodeId !== null
-                ? 'withdrawn'
-                : "team{$data->teamMember->teamYear}";
+            $index = "team{$memberData->teamMember->teamYear}";
+            if ($memberData->withdrawCodeId !== null
+                || ($includeXferAsWithdrawn && $memberData->xferOut)
+            ) {
+                $index = 'withdrawn';
+            }
 
-            $reportData[$index]["Q{$data->teamMember->quarterNumber}"][] = $data;
+            $reportData[$index]["Q{$memberData->teamMember->quarterNumber}"][] = $memberData;
         }
 
         return compact('reportData');

--- a/src/app/Reports/Arrangements/TravelRoomingByTeamYear.php
+++ b/src/app/Reports/Arrangements/TravelRoomingByTeamYear.php
@@ -44,7 +44,10 @@ class TravelRoomingByTeamYear extends BaseArrangement
         $nextQuarter = $thisQuarter->getNextQuarter();
 
         foreach ($registrationDataList as $registrationData) {
-            if ($registrationData->withdrawCodeId || $registrationData->incomingQuarterId != $nextQuarter->id) {
+            if ($registrationData->withdrawCodeId
+                || $registrationData->xferOut
+                || $registrationData->incomingQuarterId != $nextQuarter->id
+            ) {
                 continue;
             }
 

--- a/src/resources/views/globalreports/details/teammemberstatus.blade.php
+++ b/src/resources/views/globalreports/details/teammemberstatus.blade.php
@@ -65,7 +65,30 @@
                                 @endif
                             </td>
                         @endif
-                        <td>{{ is_numeric($memberData->comment) ? TmlpStats\Util::getExcelDate($memberData->comment)->format('F') : $memberData->comment }}</td>
+                        <td>
+                        <?php
+                            $comment = '';
+                            if (is_numeric($memberData->comment)) {
+                                $comment .= TmlpStats\Util::getExcelDate($memberData->comment)->format('F');
+                            } else {
+                                $comment .= trim($memberData->comment);
+                            }
+
+                            if (isset($registrations[$memberData->teamMember->personId])) {
+                                if ($comment) {
+                                    $comment .= ', ';
+                                }
+
+                                $app = $registrations[$memberData->teamMember->personId];
+                                if (is_numeric($app->comment)) {
+                                    $comment .= TmlpStats\Util::getExcelDate($app->comment)->format('F');
+                                } else {
+                                    $comment .= trim($app->comment);
+                                }
+                            }
+                        ?>
+                        {{ $comment }}
+                        </td>
                     </tr>
                 @endforeach
                 </tbody>


### PR DESCRIPTION
Fix a few issues:
- On local report -> Weekend, don't include transfers out in total for next quarter
- On regional report -> Weekend, don't include transfers out in total for next quarter
- On regional report -> Weekend -> Potentials Detail, include both team member and registration comments for T2 that registered before the weekend.