### PR TITLE
Fix several issues with the transfer check report

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -939,7 +939,17 @@ class StatsReportController extends ReportDispatchAbstractController
                         }
                         unset($incomingThisWeekByQuarter[$team][$field][$idx]);
                     } else {
-                        $incomingSummary['missing'][] = [null, $lastWeekData];
+                        $withdrewThisQuarter = false;
+                        foreach (array_flatten($incomingThisWeekByQuarter['withdrawn']) as $wd) {
+                            if ($this->objectsAreEqual($wd, $lastWeekData)) {
+                                $withdrewThisQuarter = true;
+                                break;
+                            }
+                        }
+
+                        if (!$withdrewThisQuarter) {
+                            $incomingSummary['missing'][] = [null, $lastWeekData];
+                        }
                     }
                 }
             }

--- a/src/app/TeamMemberData.php
+++ b/src/app/TeamMemberData.php
@@ -51,6 +51,7 @@ class TeamMemberData extends Model
                 return $this->teamMember->person->$name;
             case 'teamYear':
             case 'quarterNumber':
+            case 'incomingQuarter':
                 return $this->teamMember->$name;
             default:
                 return parent::__get($name);

--- a/src/resources/views/statsreports/details/peopletransfersummary.blade.php
+++ b/src/resources/views/statsreports/details/peopletransfersummary.blade.php
@@ -188,7 +188,7 @@
                 $new = $existingPair[0];
                 $old = $existingPair[1];
 
-                $attributes = [
+                $classes = $oldValues = [
                     'teamYear' => '',
                     'regDate' => '',
                     'appOutDate' => '',
@@ -196,19 +196,18 @@
                     'apprDate' => '',
                     'incomingQuarterId' => '',
                 ];
-                foreach (array_keys($attributes) as $field) {
+                foreach (array_keys($classes) as $field) {
                     if (strpos($field, 'Date') !== false) {
                         if (($new->$field && $old->$field && $new->$field->ne($old->$field))
                             || ($old->$field && !$new->$field)
                         ) {
-                            $attributes[$field] = 'class="bg-warning" title="Was ' . $old->$field->format(TmlpStats\Util::getLocaleDateFormat()) . '"';
+                            $classes[$field] = 'bg-warning';
+                            $oldValues[$field] = $old->$field;
                         }
                     } else {
                         if ($new->$field != $old->$field) {
-                            $attributes[$field] = 'class="bg-warning"';
-                            if (!preg_match('/Id$/', $field)) {
-                                $attributes[$field] .= ' title="Was ' . $old->$field . '"';
-                            }
+                            $classes[$field] = 'bg-warning';
+                            $oldValues[$field] = $old->$field;
                         }
                     }
                 }
@@ -217,30 +216,42 @@
                 <td><input type="checkbox" /></td>
                 <td>{{ $new->firstName }}</td>
                 <td>{{ $new->lastName }}</td>
-                <td {!! $attributes['teamYear'] !!} class="data-point">
+                <td class="data-point {{ $classes['teamYear'] }}">
                     {{ $new->teamYear }}
                 </td>
-                <td {!! $attributes['regDate'] !!} class="data-point">
+                <td class="data-point {{ $classes['regDate'] }}">
                     @if ($new->regDate)
                         @date($new->regDate)
+                        @if ($oldValues['regDate'])
+                            was @date($oldValues['regDate'])
+                        @endif
                     @endif
                 </td>
-                <td {!! $attributes['appOutDate'] !!} class="data-point">
+                <td class="data-point {{ $classes['appOutDate'] }}">
                     @if ($new->appOutDate)
                         @date($new->appOutDate)
+                        @if ($oldValues['appOutDate'])
+                            was @date($oldValues['appOutDate'])
+                        @endif
                     @endif
                 </td>
-                <td {!! $attributes['appInDate'] !!} class="data-point">
+                <td class="data-point {{ $classes['appInDate'] }}">
                     @if ($new->appInDate)
                         @date($new->appInDate)
+                        @if ($oldValues['appInDate'])
+                            was @date($oldValues['appInDate'])
+                        @endif
                     @endif
                 </td>
-                <td {!! $attributes['apprDate'] !!} class="data-point">
+                <td class="data-point {{ $classes['apprDate'] }}">
                     @if ($new->apprDate)
                         @date($new->apprDate)
+                        @if ($oldValues['apprDate'])
+                            was @date($oldValues['apprDate'])
+                        @endif
                     @endif
                 </td>
-                <td {!! $attributes['incomingQuarterId'] !!} class="data-point">
+                <td class="data-point {{ $classes['incomingQuarterId'] }}">
                     {{ $new->incomingQuarterId == $thisQuarter->getNextQuarter()->id ? 'Next' : 'Future' }}
                 </td>
                 <td><?php

--- a/src/resources/views/statsreports/details/peopletransfersummary.blade.php
+++ b/src/resources/views/statsreports/details/peopletransfersummary.blade.php
@@ -17,12 +17,12 @@
         </tr>
         </thead>
         <tbody>
-            @foreach (['missing', 'new'] as $type)
+            @foreach (['missing', 'new', 'changed'] as $type)
                 @if ($teamMemberSummary[$type] )
                     @foreach ($teamMemberSummary[$type] as $existingPair)
                         <?php $new = $existingPair[0]; ?>
                         <?php $old = $existingPair[1]; ?>
-                        <?php $member = $type == 'new' ? $new : $old; ?>
+                        <?php $member = $type !== 'missing' ? $new : $old; ?>
                         @if ($member->quarterNumber != 1)
                         <tr>
                             <td><input type="checkbox" /></td>
@@ -31,11 +31,14 @@
                             <td class="data-point">{{ $member->teamYear }}</td>
                             <td class="data-point">Q{{ $member->quarterNumber }}</td>
                             <td>{{ $type }}</td>
-                            <td><?php
-                                if ($type == 'new') {
-                                    if ($old) {
-                                        echo 'Withdrawn last quarter: ' . $old->withdrawCode->display;
-                                    }
+                            <td {!! ($type == 'changed') ? 'class="bg-warning"' : '' !!}><?php
+                                if ($type == 'new' && $old) {
+                                    echo 'Withdrawn last quarter: ' . $old->withdrawCode->display;
+                                } else if ($type == 'changed' && $new->incomingQuarter->id != $old->incomingQuarter->id) {
+                                    // Quarter number is calculated based on the current report date. That means when we get the quarter number
+                                    // for a person from the previous quarter, we need to manually adjust the value to be accurate.
+                                    $teamQuarterLastWeek = $old->quarterNumber - 1;
+                                    echo "Was listed as Q{$teamQuarterLastWeek} last quarter, but is Q{$new->quarterNumber} this quarter. Were they added to the correct section on the class list?";
                                 }
                             ?></td>
                         </tr>
@@ -277,35 +280,35 @@
 
         var tables = [
             {
-                id: "teamMembersTable",
-                emptyMessage: "All team members transferred correctly"
+                id: 'teamMembersTable',
+                emptyMessage: 'All team members transferred correctly'
             },
             {
-                id: "q1Table",
-                emptyMessage: "All Q1 incoming transferred"
+                id: 'q1Table',
+                emptyMessage: 'All Q1 incoming transferred'
             },
             {
-                id: "incomingTable",
-                emptyMessage: "No new or missing applications"
+                id: 'incomingTable',
+                emptyMessage: 'No new or missing applications'
             },
             {
-                id: "ongoingTable",
-                emptyMessage: "All existing incoming transferred correctly"
+                id: 'ongoingTable',
+                emptyMessage: 'All existing incoming transferred correctly'
             }
-        ];
+        ]
 
         $.each(tables, function(index, table) {
             $('#' + table.id).dataTable({
-                "paging":    false,
-                "searching": false,
-                "order": [[ 1, "asc" ]],
-                "columnDefs": [ { "targets": 0, "orderable": false } ],
+                'paging':    false,
+                'searching': false,
+                'order': [[ 1, 'asc' ]],
+                'columnDefs': [ { 'targets': 0, 'orderable': false } ],
                 fnDrawCallback: function (settings) {
                     if (settings.fnRecordsDisplay() == 0) {
-                        $(this).closest("div.tableContainer").html("<p>" + table.emptyMessage + "</p>");
+                        $(this).closest('div.tableContainer').html('<p>' + table.emptyMessage + '</p>')
                     }
                 }
-            });
-        });
-    });
+            })
+        })
+    })
 </script>

--- a/src/resources/views/statsreports/details/peopletransfersummary.blade.php
+++ b/src/resources/views/statsreports/details/peopletransfersummary.blade.php
@@ -265,7 +265,11 @@
                         $newExpectedQuarter = $new->incomingQuarterId == $thisQuarter->getNextQuarter()->id
                             ? 'next'
                             : 'in a future';
-                        echo "Was expected {$expectedQuarter} quarter, now is expected {$newExpectedQuarter} quarter.";
+                        if ($expectedQuarter == $newExpectedQuarter) {
+                            echo "Last quarter {$new->firstName} was listed as incoming in a future quarter. They are still listed as incoming in a future quarter. Please confirm this is correct.";
+                        } else {
+                            echo "Was expected {$expectedQuarter} quarter, now is expected {$newExpectedQuarter} quarter.";
+                        }
                     }
                 ?></td>
             </tr>


### PR DESCRIPTION
- Update display of incoming dates that have changed so we can take advantage of existing date formatting
- Don't include people that transferred out last quarter in transfer check this quarter
- Check continuing team members were added to the right section on the class list