### PR TITLE
Fix token auth in GlobalReport.getReportPages

### DIFF
--- a/src/app/Http/Controllers/ApiController.php
+++ b/src/app/Http/Controllers/ApiController.php
@@ -64,6 +64,10 @@ class ApiController extends ApiControllerBase
         "ValidationData.validate" => "ValidationData__validate",
     ];
 
+    protected $tokenAuthenticatedMethods = [
+        "GlobalReport__getReportPages",
+    ];
+
     protected $unauthenticatedMethods = [
         "LiveScoreboard__getCurrentScores",
     ];

--- a/src/app/Http/Controllers/ApiControllerBase.php
+++ b/src/app/Http/Controllers/ApiControllerBase.php
@@ -45,7 +45,7 @@ class ApiControllerBase extends Controller
         $callable = $this->methods[$method];
 
         if (in_array($callable, $this->tokenAuthenticatedMethods)) {
-            App::make(TokenAuthenticate::class)->manualHandle();
+            App::make(TokenAuthenticate::class)->authenticate();
         } else if (!in_array($callable, $this->unauthenticatedMethods) && Auth::user() == null) {
             throw new ApiExceptions\NotAuthenticatedException('You must be authenticated to access the api.');
         }

--- a/src/app/Http/Controllers/ApiControllerBase.php
+++ b/src/app/Http/Controllers/ApiControllerBase.php
@@ -2,12 +2,14 @@
 
 namespace TmlpStats\Http\Controllers;
 
+use App;
 use Auth;
 use Illuminate\Http\Request;
 use Response;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use TmlpStats\Api\Exceptions as ApiExceptions;
 use TmlpStats\Api\Parsers;
+use TmlpStats\Http\Middleware\TokenAuthenticate;
 
 class ApiControllerBase extends Controller
 {
@@ -42,7 +44,9 @@ class ApiControllerBase extends Controller
         }
         $callable = $this->methods[$method];
 
-        if (!in_array($callable, $this->unauthenticatedMethods) && Auth::user() == null) {
+        if (in_array($callable, $this->tokenAuthenticatedMethods)) {
+            App::make(TokenAuthenticate::class)->manualHandle();
+        } else if (!in_array($callable, $this->unauthenticatedMethods) && Auth::user() == null) {
             throw new ApiExceptions\NotAuthenticatedException('You must be authenticated to access the api.');
         }
 

--- a/src/app/Http/Middleware/TokenAuthenticate.php
+++ b/src/app/Http/Middleware/TokenAuthenticate.php
@@ -1,13 +1,11 @@
 <?php
 namespace TmlpStats\Http\Middleware;
 
-use Illuminate\Contracts\Auth\Guard;
-use TmlpStats\ReportToken;
-use TmlpStats\User;
-
 use Auth;
 use Closure;
+use Illuminate\Contracts\Auth\Guard;
 use Session;
+use TmlpStats\ReportToken;
 
 class TokenAuthenticate
 {
@@ -30,20 +28,16 @@ class TokenAuthenticate
     }
 
     /**
-     * Authenticate user based on a valid bearer token
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
+     * Run token authenticator manually
      */
-    public function handle($request, Closure $next)
+    public function manualHandle()
     {
         if (Session::has('reportTokenId')) {
 
             if (!$this->auth->check() && !$this->auth->user()) {
 
                 $reportToken = ReportToken::find(Session::get('reportTokenId'));
-                if (!$reportToken->isValid()) {
+                if (!$reportToken || !$reportToken->isValid()) {
                     abort(403);
                 }
 
@@ -55,9 +49,19 @@ class TokenAuthenticate
                 Session::set('homePath', $reportToken->getReportPath());
             }
         }
+    }
+
+    /**
+     * Authenticate user based on a valid bearer token
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $this->manualHandle();
 
         return $next($request);
     }
-
-
 }

--- a/src/app/Http/Middleware/TokenAuthenticate.php
+++ b/src/app/Http/Middleware/TokenAuthenticate.php
@@ -30,7 +30,7 @@ class TokenAuthenticate
     /**
      * Run token authenticator manually
      */
-    public function manualHandle()
+    public function authenticate()
     {
         if (Session::has('reportTokenId')) {
 
@@ -60,7 +60,7 @@ class TokenAuthenticate
      */
     public function handle($request, Closure $next)
     {
-        $this->manualHandle();
+        $this->authenticate();
 
         return $next($request);
     }

--- a/src/app/Util.php
+++ b/src/app/Util.php
@@ -223,9 +223,7 @@ class Util
      */
     public static function getRandomString()
     {
-        $b64Hash = base64_encode(hash('sha512', openssl_random_pseudo_bytes(32), true));
-
-        return str_replace(['+','/','='], ['-','_',''], $b64Hash);
+        return str_random(64);
     }
 
     /**

--- a/src/config/reports.yml
+++ b/src/config/reports.yml
@@ -5,6 +5,7 @@ access_levels:
     TBD: [TBD, global]
     regional_up: [regional, global, global_leader]
     any: __any__
+    token: __token__
 
 scopes:
   local:
@@ -202,6 +203,7 @@ api:
 
       getReportPages:
         desc: Get the global report page(s) named
+        access: token
         params:
           - name: globalReport
             type: GlobalReport

--- a/src/resources/views/api/codegen/api_controller_output.blade.php
+++ b/src/resources/views/api/codegen/api_controller_output.blade.php
@@ -23,6 +23,14 @@ class ApiController extends ApiControllerBase
 @endforeach
     ];
 
+    protected $tokenAuthenticatedMethods = [
+@foreach ($apiMethodsFlat as $method)
+@if ($method->access === 'token')
+        "{{ $method->absNameLocal() }}",
+@endif
+@endforeach
+    ];
+
     protected $unauthenticatedMethods = [
 @foreach ($apiMethodsFlat as $method)
 @if ($method->access === 'any')


### PR DESCRIPTION
Changes to use Api.GlobalReport.getReportPages to fetch the regional report data broke token auth (auth used for report tokens).

Fixed by adding support in ApiController