### PR TITLE
Fix bug in updating center info

### DIFF
--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -135,6 +135,11 @@ class Center extends Model
             'name' => 'centerReportMailingList',
         ]);
 
+        // No list and no existing setting. Nothing to do
+        if (!$list && !$setting->exists) {
+            return true;
+        }
+
         // If the list is empty, remove the setting if it exists and abort
         if (!$list) {
             return $setting->delete();

--- a/src/app/Http/Controllers/AdminCenterController.php
+++ b/src/app/Http/Controllers/AdminCenterController.php
@@ -164,13 +164,14 @@ class AdminCenterController extends Controller
             }
         }
 
+        // Save what we have so far. Mailing lists saved separately
+        $center->update($input);
+
         // Don't check if there is a value first so we can remove existing lists
         $quarter = Models\Quarter::getQuarterByDate(Carbon::now(), $center->region);
         if (!$this->saveMailingList($request, $center, $quarter)) {
             return redirect("admin/centers/{$center->abbreviation}/edit")->withInput();
         }
-
-        $center->update($input);
 
         $redirect = "admin/centers";
         if ($request->has('previous_url')) {


### PR DESCRIPTION
There was a bug where if a center didn't have an existing mailing list and you tried to save other changes, the update operation would fail before saving because it was unable to delete the non-existent mailing list setting. Fixed by checking first