### PR TITLE
Automatically setup a new global report and pick appropriate date

### DIFF
--- a/src/app/Api/Context.php
+++ b/src/app/Api/Context.php
@@ -186,6 +186,29 @@ class Context
         return App::make(Controller::class)->getReportingDate();
     }
 
+    public function getSubmissionReportingDate()
+    {
+        $reportingDate = null;
+
+        switch (Carbon::now()->dayOfWeek) {
+            case Carbon::SATURDAY:
+                $reportingDate = new Carbon('last friday');
+                break;
+            case Carbon::SUNDAY:
+            case Carbon::MONDAY:
+            case Carbon::TUESDAY:
+            case Carbon::WEDNESDAY:
+            case Carbon::THURSDAY:
+                $reportingDate = new Carbon('next friday');
+                break;
+            case Carbon::FRIDAY:
+                $reportingDate = Carbon::now();
+                break;
+        }
+
+        return $reportingDate->startOfDay();
+    }
+
     /**
      * Set the action to be routed to on date select.
      * Used in views that have a reportingDate route parameter to allow the date select dropdown to work.

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -21,7 +21,7 @@ class SubmissionCore extends AuthenticatedApiBase
         $this->checkCenterDate($center, $reportingDate);
 
         // Make sure a global report exists
-        $this->globalReport = Models\GlobalReport::firstOrCreate([
+        $globalReport = Models\GlobalReport::firstOrCreate([
             'reporting_date' => $reportingDate,
         ]);
 

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -20,6 +20,11 @@ class SubmissionCore extends AuthenticatedApiBase
     {
         $this->checkCenterDate($center, $reportingDate);
 
+        // Make sure a global report exists
+        $this->globalReport = Models\GlobalReport::firstOrCreate([
+            'reporting_date' => $reportingDate,
+        ]);
+
         $localReport = App::make(LocalReport::class);
         $rq = $this->reportAndQuarter($center, $reportingDate);
 

--- a/src/resources/views/partials/navbar.blade.php
+++ b/src/resources/views/partials/navbar.blade.php
@@ -13,6 +13,10 @@ $regions = TmlpStats\Region::isGlobal()->get();
 $currentRegion = $context->getGlobalRegion(false);
 $currentCenter = $context->getCenter(true);
 
+// This has to be a separate variable because the submission reporting date and the reports reporting date use
+// different logic to determine the best value. Submission needs to default to the next week
+$submissionReportingDate = $context->getSubmissionReportingDate();
+
 $crd = null;
 $showNextQtrAccountabilities = false;
 if ($currentCenter !== null && $reportingDate != null) {
@@ -70,7 +74,7 @@ $showNavCenterSelect = isset($showNavCenterSelect) ? $showNavCenterSelect : fals
 
                         @can ('showNewSubmissionUi', $currentCenter)
                         <li {!! Request::is('submission') ? 'class="active"' : '' !!}>
-                            <a href="{{ action('CenterController@submission', ['abbr' => $currentCenter->abbrLower(), 'reportingDate' => $reportingDateString]) }}">Submit Report (beta)</a>
+                            <a href="{{ action('CenterController@submission', ['abbr' => $currentCenter->abbrLower(), 'reportingDate' => $submissionReportingDate->toDateString()]) }}">Submit Report (beta)</a>
                         </li>
                         @endcan
 


### PR DESCRIPTION
When you click Submit Report, default to the up-coming Friday's date (except for Saturdays which are usually revisions).

If a global report doesn't already exist, create one.