### PR TITLE
Remove redundant message that some objects need to be updated each week

### DIFF
--- a/src/app/Api/ValidationData.php
+++ b/src/app/Api/ValidationData.php
@@ -25,7 +25,7 @@ class ValidationData extends AuthenticatedApiBase
         'TeamMember' => [
             'apiClass' => TeamMember::class,
             'typeName' => 'TeamMember',
-            'updateRequired' => true,
+            'updateRequired' => false,
         ],
         'Course' => [
             'apiClass' => Course::class,
@@ -35,7 +35,7 @@ class ValidationData extends AuthenticatedApiBase
         'Scoreboard' => [
             'apiClass' => Scoreboard::class,
             'typeName' => 'Scoreboard',
-            'updateRequired' => true,
+            'updateRequired' => false,
         ],
     ];
 

--- a/src/tests/functional/Api/ValidationDataTest.php
+++ b/src/tests/functional/Api/ValidationDataTest.php
@@ -299,14 +299,6 @@ class ValidationDataTest extends FunctionalTestAbstract
                     ['id' => 'GENERAL_MISSING_VALUE'],
                     ['id' => 'GENERAL_MISSING_VALUE'],
                     ['id' => 'GENERAL_MISSING_VALUE'],
-                    [
-                        'id' => 'VALDATA_NOT_UPDATED',
-                        'level' => 'error',
-                        'reference' => [
-                            'id' => $reportingDate->toDateString(),
-                            'type' => 'Scoreboard',
-                        ],
-                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
This was added to make sure that the statistician made a conscious effort to update each thing each week. Given how we ended up implementing the submission data store, this isn't actually needed.