### PR TITLE
Fix errors on class list and applications

### DIFF
--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -130,10 +130,18 @@ class Application extends ApiBase
             }
             $teamApp = Domain\TeamApplication::fromArray($data);
         }
-        $submissionData->store($center, $reportingDate, $teamApp);
-
         $report = LocalReport::ensureStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $teamApp, $appId);
+
+        if ($appId > 0 || $validationResults['valid']) {
+            $submissionData->store($center, $reportingDate, $teamApp);
+        } else {
+            return [
+                'success' => false,
+                'valid' => $validationResults['valid'],
+                'messages' => $validationResults['messages'],
+            ];
+        }
 
         return [
             'success' => true,

--- a/src/app/Validate/Objects/ApiTeamApplicationValidator.php
+++ b/src/app/Validate/Objects/ApiTeamApplicationValidator.php
@@ -291,7 +291,7 @@ class ApiTeamApplicationValidator extends ApiObjectsValidatorAbstract
         if ($this->isTimeToCheckTravel()) {
             if (is_null($data->travel)) {
                 // Error if no comment provided, warning to look at it otherwise
-                if (is_null($data->comment)) {
+                if (!$data->comment) {
                     $this->addMessage('error', [
                         'id' => 'TEAMAPP_TRAVEL_COMMENT_MISSING',
                         'ref' => $data->getReference(['field' => 'comment']),
@@ -306,7 +306,7 @@ class ApiTeamApplicationValidator extends ApiObjectsValidatorAbstract
             }
             if (is_null($data->room)) {
                 // Error if no comment provided, warning to look at it otherwise
-                if (is_null($data->comment)) {
+                if (!$data->comment) {
                     $this->addMessage('error', [
                         'id' => 'TEAMAPP_ROOM_COMMENT_MISSING',
                         'ref' => $data->getReference(['field' => 'comment']),

--- a/src/app/Validate/Objects/ApiTeamMemberValidator.php
+++ b/src/app/Validate/Objects/ApiTeamMemberValidator.php
@@ -212,7 +212,7 @@ class ApiTeamMemberValidator extends ApiObjectsValidatorAbstract
         if ($this->isTimeToCheckTravel()) {
             if (!$data->travel) {
                 // Error if no comment provided, warning to look at it otherwise
-                if (is_null($data->comment)) {
+                if (!$data->comment) {
                     $this->addMessage('error', [
                         'id' => 'CLASSLIST_TRAVEL_COMMENT_MISSING',
                         'ref' => $data->getReference(['field' => 'comment']),
@@ -227,7 +227,7 @@ class ApiTeamMemberValidator extends ApiObjectsValidatorAbstract
             }
             if (!$data->room) {
                 // Error if no comment provided, warning to look at it otherwise
-                if (is_null($data->comment)) {
+                if (!$data->comment) {
                     $this->addMessage('error', [
                         'id' => 'CLASSLIST_ROOM_COMMENT_MISSING',
                         'ref' => $data->getReference(['field' => 'comment']),

--- a/src/resources/assets/js/reusable/form_utils/DateInput.jsx
+++ b/src/resources/assets/js/reusable/form_utils/DateInput.jsx
@@ -39,6 +39,8 @@ class DateInputView extends React.Component {
         let date
         if (modelValue) {
             date = moment(modelValue)
+        } else {
+            date = moment().day('Saturday')
         }
 
         const id = 'dp-' + model.replace('.', '-')

--- a/src/resources/assets/js/reusable/form_utils/DateInput.jsx
+++ b/src/resources/assets/js/reusable/form_utils/DateInput.jsx
@@ -39,8 +39,6 @@ class DateInputView extends React.Component {
         let date
         if (modelValue) {
             date = moment(modelValue)
-        } else {
-            date = moment().day('Saturday')
         }
 
         const id = 'dp-' + model.replace('.', '-')

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -127,8 +127,8 @@ class _EditCreate extends ApplicationsBase {
         let messages = []
         if (app && app.id) {
             messages = this.props.messages[app.id]
-        } else if (this.isNewApp() && this.props.messages['new']) {
-            messages = this.props.messages['new']
+        } else if (this.isNewApp() && this.props.messages['create']) {
+            messages = this.props.messages['create']
         }
 
         return (
@@ -230,19 +230,12 @@ class _EditCreate extends ApplicationsBase {
                 return
             }
 
-            if (result.success && result.storedId) {
-                data = objectAssign({}, data, {id: result.storedId})
-                this.props.dispatch(appsCollection.replaceItem(data))
-            }
-
-            this.props.dispatch(messages.replace(data.id, result.messages))
-
-            if (result.messages.length) {
+            if (result.messages && result.messages.length) {
                 scrollIntoView('submission-flow')
 
-                if (this.isNewApp()) {
-                    // New apps that have errors, now have an id. Redirect to the edit view
-                    this.props.router.push(this.baseUri() + '/applications/edit/' + data.id)
+                // Redirect to edit view if there are warning messages
+                if (this.isNewApp() && result.valid) {
+                    this.props.router.push(this.baseUri() + '/applications/edit/' + result.storedId)
                 }
             } else if (result.valid) {
                 this.props.router.push(this.baseUri() + '/applications')

--- a/src/resources/assets/js/submission/team_members/actions.js
+++ b/src/resources/assets/js/submission/team_members/actions.js
@@ -79,15 +79,19 @@ export function setExitChoice(exitChoice) {
 export function stashTeamMember(center, reportingDate, data) {
     return teamMembersData.runNetworkAction('save', {center, reportingDate, data}, {
         successHandler(result, { dispatch }) {
+            // The request failed before creating an id (parser error)
             if (!result.storedId) {
                 dispatch(teamMembersData.saveState({error: 'Validation Failed', messages: result.messages}))
                 setTimeout(() => { dispatch(teamMembersData.saveState('new')) }, 3000)
                 dispatch(messages.replace('create', result.messages))
                 return
             }
+
             const newData = objectAssign({}, data, {id: result.storedId, meta: result.meta})
             dispatch(messages.replace(newData.id, getMessages(result)))
             dispatch(teamMembersData.replaceItem(newData))
+
+            // If this is a new entry, clear out any messages
             if (!data.id) {
                 dispatch(messages.replace('create', []))
             }

--- a/src/tests/Unit/Validate/Objects/ApiTeamApplicationValidatorTest.php
+++ b/src/tests/Unit/Validate/Objects/ApiTeamApplicationValidatorTest.php
@@ -969,12 +969,50 @@ class ApiTeamApplicationValidatorTest extends ApiValidatorTestAbstract
                 ],
                 false,
             ],
+            // ValidateTravel Fails When Missing Travel and comment is an empty string
+            [
+                [
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => '',
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => 'next',
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [
+                    $this->getMessageData($this->messageTemplate, [
+                        'id' => 'TEAMAPP_TRAVEL_COMMENT_MISSING',
+                        'reference.field' => 'comment',
+                    ]),
+                ],
+                false,
+            ],
             // ValidateTravel Fails When Missing Room
             [
                 [
                     'travel' => true,
                     'room' => null,
                     'comment' => null,
+                    'wdDate' => null,
+                    'withdrawCode' => null,
+                    'incomingQuarter' => 'next',
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [
+                    $this->getMessageData($this->messageTemplate, [
+                        'id' => 'TEAMAPP_ROOM_COMMENT_MISSING',
+                        'reference.field' => 'comment',
+                    ]),
+                ],
+                false,
+            ],
+            // ValidateTravel Fails When Missing Room and comment is an empty string
+            [
+                [
+                    'travel' => true,
+                    'room' => null,
+                    'comment' => '',
                     'wdDate' => null,
                     'withdrawCode' => null,
                     'incomingQuarter' => 'next',

--- a/src/tests/Unit/Validate/Objects/ApiTeamMemberValidatorTest.php
+++ b/src/tests/Unit/Validate/Objects/ApiTeamMemberValidatorTest.php
@@ -761,12 +761,44 @@ class ApiTeamMemberValidatorTest extends ApiValidatorTestAbstract
                 ],
                 false,
             ],
+            // ValidateTravel Fails When Missing Travel and comment is an empty string
+            [
+                [
+                    'travel' => null,
+                    'room' => true,
+                    'comment' => '',
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [
+                    $this->getMessageData($this->messageTemplate, [
+                        'id' => 'CLASSLIST_TRAVEL_COMMENT_MISSING',
+                        'reference.field' => 'comment',
+                    ]),
+                ],
+                false,
+            ],
             // ValidateTravel Fails When Missing Room
             [
                 [
                     'travel' => true,
                     'room' => null,
                     'comment' => null,
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [
+                    $this->getMessageData($this->messageTemplate, [
+                        'id' => 'CLASSLIST_ROOM_COMMENT_MISSING',
+                        'reference.field' => 'comment',
+                    ]),
+                ],
+                false,
+            ],
+            // ValidateTravel Fails When Missing Room and comment is an empty string
+            [
+                [
+                    'travel' => true,
+                    'room' => null,
+                    'comment' => '',
                     '__reportingDate' => Carbon::parse('2016-10-07'),
                 ],
                 [

--- a/src/tests/functional/Api/ApplicationTest.php
+++ b/src/tests/functional/Api/ApplicationTest.php
@@ -173,6 +173,8 @@ class ApplicationTest extends FunctionalTestAbstract
      */
     public function testStashFailsValidation($id)
     {
+        $isNew = $id === null;
+
         $reportingDate = '2016-04-15';
 
         $parameters = [
@@ -190,7 +192,7 @@ class ApplicationTest extends FunctionalTestAbstract
             ],
         ];
 
-        if ($id) {
+        if (!$isNew) {
             $parameters['data']['id'] = $this->application->id;
         }
 
@@ -198,18 +200,20 @@ class ApplicationTest extends FunctionalTestAbstract
         $applicationDataId = $this->applicationData->id;
 
         $expectedResponse = [
-            'success' => true,
+            'success' => !$isNew,
             'valid' => false,
         ];
 
         $this->post('/api', $parameters, $this->headers)->seeJsonHas($expectedResponse);
         $result1 = App::make(Api\SubmissionData::class)->allForType($this->center, new Carbon($reportingDate), Domain\TeamApplication::class);
 
-        $this->assertEquals(1, count($result1));
-        $result = $result1[0];
-        $this->assertEquals('2016-04-09', $result->appOutDate->toDateString());
-        $this->assertEquals('2016-04-10', $result->appInDate->toDateString());
-        $this->assertEquals('2016-04-08', $result->apprDate->toDateString());
+        $this->assertEquals($isNew ? 0 : 1, count($result1));
+        if (!$isNew) {
+            $result = $result1[0];
+            $this->assertEquals('2016-04-09', $result->appOutDate->toDateString());
+            $this->assertEquals('2016-04-10', $result->appInDate->toDateString());
+            $this->assertEquals('2016-04-08', $result->apprDate->toDateString());
+        }
     }
 
     public function providerStashFailsValidation()


### PR DESCRIPTION
Fix the follow:
- Display team member errors when creating a new member
- Redirect to edit page when creating a new member that has warnings
- Stop creating applications when there are errors
- Check if comment actually has text when validating comments for travel/rooming
- A couple cosmetic changes
