### PR TITLE
Fix submission bugs

### DIFF
--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -169,6 +169,7 @@ class SubmissionCore extends AuthenticatedApiBase
                                             or coalesce(p.reg_date,\'\') != coalesce(sda.regDate,\'\')
                                             or coalesce(p.is_reviewer,\'\') != coalesce(sda.isReviewer,\'\'))',
                         [$r->id]);
+                    $reg_id = $r->stored_id;
                     $person_id = $r->person_id;
                 };
 


### PR DESCRIPTION
Fixes the following issues:
- When submitting a report, 2 stats reports were created
- When updating existing applications, data objects were given 0 for the registration id
- Insert data rows for apps that weren't updated by copying last weeks
- Insert data rows for withdrawn team members that weren't updated by copying last weeks
- Simplifies logic to attach new stats report to global report