### PR TITLE
Make submission ui visible with setting

### DIFF
--- a/src/app/Policies/CenterPolicy.php
+++ b/src/app/Policies/CenterPolicy.php
@@ -3,12 +3,18 @@
 namespace TmlpStats\Policies;
 
 use TmlpStats\Center;
+use TmlpStats\Setting;
 use TmlpStats\User;
 
 class CenterPolicy extends Policy
 {
     public function showNewSubmissionUi(User $user, Center $center)
     {
+        $setting = Setting::get('showNewSubmissionUi', $center);
+        if ($setting) {
+            return true;
+        }
+
         return false; // Only used to trigger the link, and only global statisticians will have it.
     }
 

--- a/src/app/Validate/Objects/ApiTeamApplicationValidator.php
+++ b/src/app/Validate/Objects/ApiTeamApplicationValidator.php
@@ -102,11 +102,10 @@ class ApiTeamApplicationValidator extends ApiObjectsValidatorAbstract
         }
 
         if (is_null($data->committedTeamMemberId) && is_null($data->withdrawCodeId)) {
-            $this->addMessage('error', [
+            $this->addMessage('warning', [
                 'id' => 'TEAMAPP_NO_COMMITTED_TEAM_MEMBER',
                 'ref' => $data->getReference(['field' => 'committedTeamMemberId']),
             ]);
-            $isValid = false;
         }
 
         return $isValid;

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -289,7 +289,6 @@ class ApplicationsAddView extends _EditCreate {
                     lastName: '',
                     teamYear: 1,
                     regDate: this.reportingDateString(),
-                    committedTeamMember: '',
                     incomingQuarter: centerQuarters[0].quarterId
                 }
                 this.props.dispatch(chooseApplication('', blankApp))


### PR DESCRIPTION
- Add setting to gate displaying submission ui nav link
- Make committed team member optional so you can save apps during the first week.