### PR TITLE
Show errors for new but already stashed team members

### DIFF
--- a/src/app/Api/Course.php
+++ b/src/app/Api/Course.php
@@ -129,12 +129,7 @@ class Course extends ApiBase
         App::make(SubmissionCore::class)->checkCenterDate($center, $reportingDate);
 
         $submissionData = App::make(SubmissionData::class);
-        $courseId = array_get($data, 'id', null);
-        if (is_numeric($courseId)) {
-            $courseId = intval($courseId);
-        }
-
-        $isNew = ($courseId === null);
+        $courseId = $submissionData->numericStorageId($data, 'id');
 
         if ($courseId !== null && $courseId > 0) {
             $courseModel = Models\Course::findOrFail($courseId);
@@ -151,17 +146,12 @@ class Course extends ApiBase
                 'currentXfer',
             ]);
         } else {
-            if (!$courseId) {
-                $courseId = $submissionData->generateId();
-                $data['id'] = $courseId;
-            }
             $course = Domain\Course::fromArray($data);
         }
-
         $report = LocalReport::ensureStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $course, $courseId);
 
-        if (!$isNew || $validationResults['valid']) {
+        if (!isset($data['_idGenerated']) || $validationResults['valid']) {
             $submissionData->store($center, $reportingDate, $course);
         } else {
             return [

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -88,7 +88,7 @@ class TeamMember extends AuthenticatedApiBase
         $report = LocalReport::ensureStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $domain, $teamMemberId);
 
-        if ($teamMemberId > 0 || $validationResults['valid']) {
+        if (!isset($data['_idGenerated']) || $validationResults['valid']) {
             $submissionData->store($center, $reportingDate, $domain);
         } else {
             return [

--- a/src/app/Domain/ParserDomain.php
+++ b/src/app/Domain/ParserDomain.php
@@ -106,7 +106,7 @@ class ParserDomain implements Arrayable, \JsonSerializable, Referenceable
     public static function fromArray($input, $requiredParams = [])
     {
         $obj = new static();
-        $obj->updateFromArray($input);
+        $obj->updateFromArray($input, $requiredParams);
 
         return $obj;
     }

--- a/src/resources/assets/js/reusable/redux_loader/base.js
+++ b/src/resources/assets/js/reusable/redux_loader/base.js
@@ -12,6 +12,9 @@ const LOADER_DEFAULT_OPTS = {
     transformData: x => x,
     successHandler: (data, {loader}) =>{
         return loader.replaceCollection(data)
+    },
+    failHandler: (err) =>{
+        throw err
     }
 }
 
@@ -109,9 +112,10 @@ export class ReduxLoader {
             }
 
             const fail = (err) => {
-                if (actionData.failHandler) {
-                    const fixedErr = (err.error) ? err : {error: err.message || err}
-                    actionData.failHandler(fixedErr, info)
+                const fixedErr = (err.error) ? err : {error: err.message || err}
+                const result = actionData.failHandler(fixedErr, info)
+                if (result) {
+                    dispatch(result)
                 }
                 if (actionData.setLoaded && !actionData.inGroup) {
                     dispatch(loadAction('loaded'))

--- a/src/resources/assets/js/reusable/redux_loader/base.js
+++ b/src/resources/assets/js/reusable/redux_loader/base.js
@@ -108,16 +108,18 @@ export class ReduxLoader {
                 return tdata
             }
 
-            const failHandler = (err) => {
-                if (!actionData.inGroup) {
-                    const fixedErr = (err.error)? err : {error: err.message || err}
-                    dispatch(loadAction(fixedErr))
+            const fail = (err) => {
+                if (actionData.failHandler) {
+                    const fixedErr = (err.error) ? err : {error: err.message || err}
+                    actionData.failHandler(fixedErr, info)
                 }
-                throw err
+                if (actionData.setLoaded && !actionData.inGroup) {
+                    dispatch(loadAction('loaded'))
+                }
             }
 
             // loader, saver, etc
-            return actionData.api(params, info).then(success, failHandler)
+            return actionData.api(params, info).then(success, fail)
         }
     }
 

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -252,7 +252,7 @@ class ApplicationsEditView extends _EditCreate {
             if (!this.props.currentApp || this.props.currentApp.id != appId) {
                 let app = this.getAppById(appId)
                 if (app){
-                    app = objectAssign({}, app, {committedTeamMember: app.committedTeamMember || ''})
+                    app = objectAssign({}, app, {committedTeamMember: app.committedTeamMember || null})
                     this.props.dispatch(chooseApplication(appId, app))
                 }
             }

--- a/src/resources/assets/js/submission/team_members/actions.js
+++ b/src/resources/assets/js/submission/team_members/actions.js
@@ -98,6 +98,12 @@ export function stashTeamMember(center, reportingDate, data) {
             if (!data.id) {
                 dispatch(messages.replace('create', []))
             }
+        },
+
+        failHandler(err, { dispatch }) {
+            // If this is a parser error, we won't have an ID yet, use 'create'
+            const id = data.id ? data.id : 'create'
+            dispatch(messages.replace(id, getMessages(err)))
         }
     })
 }


### PR DESCRIPTION
- Display errors for new, already stashed team members
- Make incoming quarter required
- Catch parser errors in class list and display them
- Align all stash methods to use the same method of finding new objects
- Fix bug in applications where committed team member is required when editing an existing app