### PR TITLE
Reset new application errors after submitting

### DIFF
--- a/src/resources/assets/js/submission/applications/actions.js
+++ b/src/resources/assets/js/submission/applications/actions.js
@@ -51,6 +51,10 @@ export function saveApplication(center, reportingDate, data) {
     return (dispatch) => {
         const reset = () => dispatch(saveAppState('new'))
 
+        if (data.committedTeamMember == '') {
+            data = objectAssign({}, data, {committedTeamMember: undefined})
+        }
+
         dispatch(saveAppState('loading'))
         return Api.Application.stash({
             center, reportingDate, data
@@ -62,9 +66,9 @@ export function saveApplication(center, reportingDate, data) {
                 return result
             }
 
-            data = objectAssign({}, data, {id: result.storedId})
-            dispatch(appsCollection.replaceItem(data))
-            dispatch(messages.replace(data.id, result.messages))
+            let newData = objectAssign({}, data, {id: result.storedId})
+            dispatch(appsCollection.replaceItem(newData))
+            dispatch(messages.replace(result.storedId, result.messages))
 
             // We successfully saved, reset any existing parser messages
             if (!data.id) {

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -244,7 +244,6 @@ class _EditCreate extends ApplicationsBase {
             }
         })
     }
-
 }
 
 class ApplicationsEditView extends _EditCreate {
@@ -254,7 +253,7 @@ class ApplicationsEditView extends _EditCreate {
             if (!this.props.currentApp || this.props.currentApp.id != appId) {
                 let app = this.getAppById(appId)
                 if (app){
-                    app = objectAssign({}, app, {committedTeamMember: app.committedTeamMember || undefined})
+                    app = objectAssign({}, app, {committedTeamMember: app.committedTeamMember || ''})
                     this.props.dispatch(chooseApplication(appId, app))
                 }
             }
@@ -291,7 +290,8 @@ class ApplicationsAddView extends _EditCreate {
                     lastName: '',
                     teamYear: 1,
                     regDate: this.reportingDateString(),
-                    incomingQuarter: centerQuarters[0].quarterId
+                    incomingQuarter: centerQuarters[0].quarterId,
+                    committedTeamMember: '',
                 }
                 this.props.dispatch(chooseApplication('', blankApp))
             }

--- a/src/resources/assets/js/submission/courses/actions.js
+++ b/src/resources/assets/js/submission/courses/actions.js
@@ -57,9 +57,9 @@ export function saveCourse(center, reportingDate, data) {
                 return result
             }
 
-            data = objectAssign({}, data, {id: result.storedId, meta: result.meta})
-            dispatch(coursesCollection.replaceItem(data))
-            dispatch(messages.replace(data.id, result.messages))
+            let newData = objectAssign({}, data, {id: result.storedId, meta: result.meta})
+            dispatch(coursesCollection.replaceItem(newData))
+            dispatch(messages.replace(newData.id, result.messages))
 
             // We successfully saved, reset any existing parser messages
             if (!data.id) {


### PR DESCRIPTION
- Fix bug in resetting messages when opening a new application
- Fix bug in resetting messages when opening a new course
- Fix bug that prevented application's committed team member from resetting when opening a new app