### PR TITLE
Fix accountability imports and email lists

### DIFF
--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -104,7 +104,6 @@ class SubmissionCore extends AuthenticatedApiBase
             $lastStatsReportDate = $reportingDate->copy()->subWeek();
 
             $reportNow = $reportingDate->copy()->setTime(15, 0, 0);
-            $quarterStartDate = $statsReport->quarter->getQuarterStartDate($statsReport->center)->setTime(15, 0, 0);
             $quarterEndDate = $statsReport->quarter->getQuarterEndDate($statsReport->center)->setTime(14, 59, 59);
 
             $isFirstWeek = $statsReport->reportingDate->eq($statsReport->quarter->getFirstWeekDate($statsReport->center));

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -400,7 +400,7 @@ class SubmissionCore extends AuthenticatedApiBase
 
                 $person = Models\Person::find($result[$accountability->id]->person_id);
                 if (!$person) {
-                    // TODO: log an errors?
+                    Log::error("Person {$result[$accountability->id]->person_id} was submitted in accountability_person but doesn't exist.");
                     continue;
                 }
 

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -460,6 +460,7 @@ class SubmissionCore extends AuthenticatedApiBase
         $quarter = $statsReport->quarter;
         $center  = $statsReport->center;
         $region  = $center->region;
+        $reportingDate = $statsReport->reportingDate;
 
         $submittedAt = $statsReport->submittedAt->copy()->setTimezone($center->timezone);
 
@@ -468,12 +469,14 @@ class SubmissionCore extends AuthenticatedApiBase
 
         $isLate = $submittedAt->gt($due);
 
-        $programManager         = $center->getProgramManager($quarter);
-        $classroomLeader        = $center->getClassroomLeader($quarter);
-        $t1TeamLeader           = $center->getT1TeamLeader($quarter);
-        $t2TeamLeader           = $center->getT2TeamLeader($quarter);
-        $statistician           = $center->getStatistician($quarter);
-        $statisticianApprentice = $center->getStatisticianApprentice($quarter);
+        $reportNow = $reportingDate->copy()->setTime(15, 0, 0);
+
+        $programManager         = $center->getProgramManager($quarter, $reportNow);
+        $classroomLeader        = $center->getClassroomLeader($quarter, $reportNow);
+        $t1TeamLeader           = $center->getT1TeamLeader($quarter, $reportNow);
+        $t2TeamLeader           = $center->getT2TeamLeader($quarter, $reportNow);
+        $statistician           = $center->getStatistician($quarter, $reportNow);
+        $statisticianApprentice = $center->getStatisticianApprentice($quarter, $reportNow);
 
         $emailMap = [
             'center'                 => $center->statsEmail,
@@ -525,7 +528,6 @@ class SubmissionCore extends AuthenticatedApiBase
 
         $centerName    = $center->name;
         $comment       = $statsReport->submitComment;
-        $reportingDate = $statsReport->reportingDate;
         try {
             Mail::send('emails.apistatssubmitted',
                 compact('centerName', 'comment', 'due', 'isLate', 'isResubmitted', 'mobileDashUrl',

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -405,7 +405,7 @@ class SubmissionCore extends AuthenticatedApiBase
                 }
 
                 // If the person doesn't already have this accountability, add it and remove previous holder
-                if (!$person->hasAccountability($accountability)) {
+                if (!$person->hasAccountability($accountability, $reportNow)) {
                     $person->takeoverAccountability($accountability, $reportNow, $quarterEndDate);
                 }
             }

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -103,8 +103,9 @@ class SubmissionCore extends AuthenticatedApiBase
 
             $lastStatsReportDate = $reportingDate->copy()->subWeek();
 
-            $quarterStartDate = $statsReport->quarter->getQuarterStartDate($statsReport->center);
-            $quarterEndDate = $statsReport->quarter->getQuarterEndDate($statsReport->center);
+            $reportNow = $reportingDate->copy()->setTime(15, 0, 0);
+            $quarterStartDate = $statsReport->quarter->getQuarterStartDate($statsReport->center)->setTime(15, 0, 0);
+            $quarterEndDate = $statsReport->quarter->getQuarterEndDate($statsReport->center)->setTime(14, 59, 59);
 
             $isFirstWeek = $statsReport->reportingDate->eq($statsReport->quarter->getFirstWeekDate($statsReport->center));
 
@@ -369,24 +370,46 @@ class SubmissionCore extends AuthenticatedApiBase
                     [$statsReport->id,$lastStatsReportDate->toDateString(),$center->id,
                       $center->id,$reportingDate->toDateString()]);
             }
-            // Process accountabilities
-            // Insert all new ones
-            //
-            // TODO: uncomment and fixme
-            //
-            // $affected = DB::insert(
-            //     'insert into accountability_person
-            //         (person_id, accountability_id, starts_at, ends_at, created_at, updated_at)
-            //     select person_id, accountability_id, sysdate(), ?, sysdate(), sysdate()
-            //     from submission_data_accountabilities a
-            //     where a.center_id=? and a.reporting_date=?
-            //         and (a.person_id, a.accountability_id) not in
-            //         (select ap.person_id, ap.accountability_id
-            //             from accountability_person ap where ap.starts_at<=?
-            //         and (ap.ends_at is null or ap.ends_at>=sysdate()));'
-            //     ,[ $quarterEndDate, $center->id,$reportingDate->toDateString(),$quarterStartDate ]);
-            // End date any accounabilities that were reassigned
-            // End date any one sthat were removed and not reassigned
+
+            // Add/update all accountability holders
+            $result = collect(DB::select(
+                'select i.* from submission_data_accountabilities i
+                    where i.center_id=? and i.reporting_date=?',
+                [$center->id, $reportingDate->toDateString()]
+            ))->keyBy(function ($item) {
+                return $item->accountability_id;
+            });
+
+            // Skip program managers and classroom leaders for now
+            // TODO: we'll need to import them at some point
+            $allAccountabilities = Models\Accountability::context('team')->whereNotIn('id', [8, 9])->get();
+            foreach ($allAccountabilities as $accountability) {
+                if (!isset($result[$accountability->id])) {
+                    // No one is listed as accountable, remove any existing accountables
+                    DB::update("
+                        UPDATE  accountability_person ap
+                        INNER JOIN people p ON p.id = ap.person_id
+                        SET ap.ends_at = ?, ap.updated_at = sysdate()
+                        WHERE
+                            ap.accountability_id = ?
+                            AND p.center_id = ?
+                            AND (ap.ends_at IS NULL OR ap.ends_at > ?)",
+                        [$reportNow->copy()->subSecond(), $accountability->id, $center->id, $reportNow]
+                    );
+                    continue;
+                }
+
+                $person = Models\Person::find($result[$accountability->id]->person_id);
+                if (!$person) {
+                    // TODO: log an errors?
+                    continue;
+                }
+
+                // If the person doesn't already have this accountability, add it and remove previous holder
+                if (!$person->hasAccountability($accountability)) {
+                    $person->takeoverAccountability($accountability, $reportNow, $quarterEndDate);
+                }
+            }
 
             // Mark stats report as 'official'
             $globalReport = Models\GlobalReport::firstOrCreate([
@@ -471,12 +494,12 @@ class SubmissionCore extends AuthenticatedApiBase
 
         $reportNow = $reportingDate->copy()->setTime(15, 0, 0);
 
-        $programManager         = $center->getProgramManager($quarter, $reportNow);
-        $classroomLeader        = $center->getClassroomLeader($quarter, $reportNow);
-        $t1TeamLeader           = $center->getT1TeamLeader($quarter, $reportNow);
-        $t2TeamLeader           = $center->getT2TeamLeader($quarter, $reportNow);
-        $statistician           = $center->getStatistician($quarter, $reportNow);
-        $statisticianApprentice = $center->getStatisticianApprentice($quarter, $reportNow);
+        $programManager         = $center->getProgramManager($reportNow);
+        $classroomLeader        = $center->getClassroomLeader($reportNow);
+        $t1TeamLeader           = $center->getT1TeamLeader($reportNow);
+        $t2TeamLeader           = $center->getT2TeamLeader($reportNow);
+        $statistician           = $center->getStatistician($reportNow);
+        $statisticianApprentice = $center->getStatisticianApprentice($reportNow);
 
         $emailMap = [
             'center'                 => $center->statsEmail,
@@ -526,8 +549,8 @@ class SubmissionCore extends AuthenticatedApiBase
                                      ->count();
         $isResubmitted = ($submittedCount > 1);
 
-        $centerName    = $center->name;
-        $comment       = $statsReport->submitComment;
+        $centerName = $center->name;
+        $comment = $statsReport->submitComment;
         try {
             Mail::send('emails.apistatssubmitted',
                 compact('centerName', 'comment', 'due', 'isLate', 'isResubmitted', 'mobileDashUrl',
@@ -574,8 +597,10 @@ class SubmissionCore extends AuthenticatedApiBase
 
     public function getEmail(Models\Person $person = null)
     {
-        return ($person && !$person->unsubscribed)
-            ? $person->email
-            : null;
+        if (!$person || $person->unsubscribed) {
+            return null;
+        }
+
+        return $person->email;
     }
 }

--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -28,37 +28,37 @@ class Center extends Model
         'active' => 'bool',
     );
 
-    public function getProgramManager()
+    public function getProgramManager($date = null)
     {
-        return $this->getAccountable('programManager');
+        return $this->getAccountable('programManager', $date);
     }
 
-    public function getClassroomLeader()
+    public function getClassroomLeader($date = null)
     {
-        return $this->getAccountable('classroomLeader');
+        return $this->getAccountable('classroomLeader', $date);
     }
 
-    public function getT1TeamLeader()
+    public function getT1TeamLeader($date = null)
     {
-        return $this->getAccountable('t1tl');
+        return $this->getAccountable('t1tl', $date);
     }
 
-    public function getT2TeamLeader()
+    public function getT2TeamLeader($date = null)
     {
-        return $this->getAccountable('t2tl');
+        return $this->getAccountable('t2tl', $date);
     }
 
-    public function getStatistician()
+    public function getStatistician($date = null)
     {
-        return $this->getAccountable('statistician');
+        return $this->getAccountable('statistician', $date);
     }
 
-    public function getStatisticianApprentice()
+    public function getStatisticianApprentice($date = null)
     {
-        return $this->getAccountable('statisticianApprentice');
+        return $this->getAccountable('statisticianApprentice', $date);
     }
 
-    public function getAccountable($accountabilityName)
+    public function getAccountable($accountabilityName, $date = null)
     {
         $accountability = Accountability::name($accountabilityName)->first();
 
@@ -66,7 +66,7 @@ class Center extends Model
             return null;
         }
 
-        return Person::byAccountability($accountability)
+        return Person::byAccountability($accountability, $date)
             ->byCenter($this)
             ->first();
     }

--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -28,37 +28,37 @@ class Center extends Model
         'active' => 'bool',
     );
 
-    public function getProgramManager($date = null)
+    public function getProgramManager(Carbon $date = null)
     {
         return $this->getAccountable('programManager', $date);
     }
 
-    public function getClassroomLeader($date = null)
+    public function getClassroomLeader(Carbon $date = null)
     {
         return $this->getAccountable('classroomLeader', $date);
     }
 
-    public function getT1TeamLeader($date = null)
+    public function getT1TeamLeader(Carbon $date = null)
     {
         return $this->getAccountable('t1tl', $date);
     }
 
-    public function getT2TeamLeader($date = null)
+    public function getT2TeamLeader(Carbon $date = null)
     {
         return $this->getAccountable('t2tl', $date);
     }
 
-    public function getStatistician($date = null)
+    public function getStatistician(Carbon $date = null)
     {
         return $this->getAccountable('statistician', $date);
     }
 
-    public function getStatisticianApprentice($date = null)
+    public function getStatisticianApprentice(Carbon $date = null)
     {
         return $this->getAccountable('statisticianApprentice', $date);
     }
 
-    public function getAccountable($accountabilityName, $date = null)
+    public function getAccountable($accountabilityName, Carbon $date = null)
     {
         $accountability = Accountability::name($accountabilityName)->first();
 

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -542,9 +542,12 @@ class StatsReportController extends ReportDispatchAbstractController
             'statistician',
             'statisticianApprentice',
         ];
+
+        $reportNow = $statsReport->reportingDate->copy()->setTime(15, 0, 0);
+
         foreach ($accountabilities as $accountability) {
             $accountabilityObj = Models\Accountability::name($accountability)->first();
-            $contacts[$accountabilityObj->display] = $statsReport->center->getAccountable($accountability);
+            $contacts[$accountabilityObj->display] = $statsReport->center->getAccountable($accountability, $reportNow);
         }
         if (!$contacts) {
             return null;

--- a/src/app/Import/ImportManager.php
+++ b/src/app/Import/ImportManager.php
@@ -265,6 +265,7 @@ class ImportManager
         $quarter = $statsReport->quarter;
         $center  = $statsReport->center;
         $region  = $center->region;
+        $reportingDate = $statsReport->reportingDate;
 
         $submittedAt = $statsReport->submittedAt->copy()->setTimezone($center->timezone);
 
@@ -273,12 +274,14 @@ class ImportManager
 
         $isLate = $submittedAt->gt($due);
 
-        $programManager         = $center->getProgramManager($quarter);
-        $classroomLeader        = $center->getClassroomLeader($quarter);
-        $t1TeamLeader           = $center->getT1TeamLeader($quarter);
-        $t2TeamLeader           = $center->getT2TeamLeader($quarter);
-        $statistician           = $center->getStatistician($quarter);
-        $statisticianApprentice = $center->getStatisticianApprentice($quarter);
+        $reportNow = $reportingDate->copy()->setTime(15, 0, 0);
+
+        $programManager         = $center->getProgramManager($reportNow);
+        $classroomLeader        = $center->getClassroomLeader($reportNow);
+        $t1TeamLeader           = $center->getT1TeamLeader($reportNow);
+        $t2TeamLeader           = $center->getT2TeamLeader($reportNow);
+        $statistician           = $center->getStatistician($reportNow);
+        $statisticianApprentice = $center->getStatisticianApprentice($reportNow);
 
         $emailMap = [
             'center'                 => $center->statsEmail,
@@ -351,7 +354,6 @@ class ImportManager
         $sheetName     = XlsxArchiver::getInstance()->getDisplayFileName($statsReport);
         $centerName    = $center->name;
         $comment       = $statsReport->submitComment;
-        $reportingDate = $statsReport->reportingDate;
         try {
             Mail::send('emails.statssubmitted',
                 compact('user', 'centerName', 'submittedAt', 'sheet', 'isLate', 'isResubmitted', 'due', 'comment',

--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -150,9 +150,13 @@ class Person extends Model
      *
      * @return bool
      */
-    public function hasAccountability(Accountability $accountability)
+    public function hasAccountability(Accountability $accountability, Carbon $when = null)
     {
-        $accountabilities = $this->getAccountabilities();
+        if ($when == null) {
+            $when = Util::now();
+        }
+
+        $accountabilities = $this->getAccountabilities($when);
         foreach ($accountabilities as $myAccountability) {
             if ($myAccountability->id == $accountability->id) {
                 return true;


### PR DESCRIPTION
- Don't email old accountables
  - When finding accountable to send emails to, we were not accurately ignoring former accountables.
  - Fixed by adding option to specify date to use when filtering.

- Import accountable submitting using online submission