### PR TITLE
Add support for running scripts in the react variant of reports.

### DIFF
--- a/src/app/Api/LocalReport.php
+++ b/src/app/Api/LocalReport.php
@@ -235,7 +235,7 @@ class LocalReport extends AuthenticatedApiBase
             'statsReportId' => $statsReport->id,
             'flags' => [
                 'canReadContactInfo' => $this->context->can('readContactInfo', $statsReport),
-                'firstWeek' => false,
+                'firstWeek' => $cq->firstWeekDate->toDateString() == $reportingDate->toDateString(),
                 'nextQtrAccountabilities' => $crd->canShowNextQtrAccountabilities(),
             ],
         ];

--- a/src/resources/assets/js/reports/tabbed_report/components.jsx
+++ b/src/resources/assets/js/reports/tabbed_report/components.jsx
@@ -111,12 +111,24 @@ export class ReportContent extends PureComponent {
             const { $ } = window
             let divId = 'content-' + report.id
             console.log('rendering inner', report.id)
+            let rawHtml = contentVec.get(level - 1) || $('#loader').html()
+            let followScript
+            if (/SCRIPTS_FOLLOW/.test(rawHtml)) {
+                let parts = rawHtml.split('<!-- SCRIPTS_FOLLOW -->')
+                rawHtml = parts[0]
+                followScript = parts[1]
+            }
+
             setTimeout(() => {
                 const container = $(`#${divId}`)
                 window.updateDates(container)
                 window.initDataTables(undefined, undefined, container)
+                if (followScript) {
+                    console.log('Running follow-up-script')
+                    $('body').append(followScript)
+                }
             })
-            let content = { __html: contentVec.get(level - 1) || $('#loader').html() }
+            let content = { __html: rawHtml }
             return <div id={divId} dangerouslySetInnerHTML={content} />
         }
     }

--- a/src/resources/views/globalreports/details/regionsummary.blade.php
+++ b/src/resources/views/globalreports/details/regionsummary.blade.php
@@ -98,5 +98,6 @@ if (!function_exists('getPercentClass')) {
     @include('reports.charts.percentages.chart', ['divId' => 'percent-container'])
 </div>
 
+<!-- SCRIPTS_FOLLOW -->
 @include('reports.charts.ratings.setup')
 @include('reports.charts.percentages.setup', ['divId' => 'percent-container'])

--- a/src/resources/views/reports/charts/percentages/setup.blade.php
+++ b/src/resources/views/reports/charts/percentages/setup.blade.php
@@ -120,6 +120,7 @@
                 <?php
                 $requestJson = "{localReport: {$statsReport->id}}";
                 ?>
+                console.log('about to hit up local report API')
                 Tmlp.Api.LocalReport.getQuarterScoreboard({!! $requestJson !!}).then(function (reportData) {
                     updateChart(reportData, "{{ $statsReport->center->name }}");
                 });

--- a/src/resources/views/reports/charts/ratings/setup.blade.php
+++ b/src/resources/views/reports/charts/ratings/setup.blade.php
@@ -125,6 +125,7 @@
                 <?php
                 $requestJson = "{localReport: {$statsReport->id}}";
                 ?>
+                console.log('about to check ratings setup')
                 Tmlp.Api.LocalReport.getQuarterScoreboard({!! $requestJson !!}).then(function (reportData) {
                     updateChart(reportData, "{{ $statsReport->center->name }}");
                 });

--- a/src/resources/views/statsreports/details/classlist.blade.php
+++ b/src/resources/views/statsreports/details/classlist.blade.php
@@ -3,7 +3,7 @@
         @if (isset($reportData[$group]))
             <br/>
             <h4>{{ ucwords($group) }}</h4>
-            <table class="table table-condensed table-striped table-hover classListTable">
+            <table class="table table-condensed table-striped table-hover classListTable want-datatable">
                 <thead>
                 <tr>
                     <th>First Name</th>
@@ -91,12 +91,3 @@
         @endif
     @endforeach
 </div>
-
-<script type="text/javascript">
-    $(document).ready(function () {
-        $('table.classListTable').dataTable({
-            "paging": false,
-            "searching": false
-        });
-    });
-</script>

--- a/src/resources/views/statsreports/details/peopletransfersummary.blade.php
+++ b/src/resources/views/statsreports/details/peopletransfersummary.blade.php
@@ -279,6 +279,7 @@
     </div>
 </div>
 
+<!-- SCRIPTS_FOLLOW -->
 <script type="text/javascript">
     $(document).ready(function() {
 

--- a/src/resources/views/statsreports/details/summary.blade.php
+++ b/src/resources/views/statsreports/details/summary.blade.php
@@ -158,6 +158,7 @@ $mobileDashUrl = "https://tmlpstats.com/m/" . strtolower($statsReport->center->a
     @include('reports.charts.ratings.chart')
 </div>
 
+<!-- SCRIPTS_FOLLOW -->
 @include('reports.charts.ratings.setup')
 
 <script>

--- a/src/resources/views/statsreports/details/tmlpregistrations.blade.php
+++ b/src/resources/views/statsreports/details/tmlpregistrations.blade.php
@@ -88,6 +88,7 @@
         @endif
     @endforeach
 </div>
+<!-- SCRIPTS_FOLLOW -->
 <script>
 $(document).ready(function() {
   $('[data-toggle="tooltip"]').tooltip();


### PR DESCRIPTION
We can use the `.html()` directive from jQuery temporarily to run
scripts by parsing them out of the bottom of the page partials.