### PR TITLE
Fix Report Token based auth for local reports

### DIFF
--- a/src/app/Http/Controllers/ApiController.php
+++ b/src/app/Http/Controllers/ApiController.php
@@ -71,6 +71,9 @@ class ApiController extends ApiControllerBase
     protected $tokenAuthenticatedMethods = [
         "GlobalReport__getReportPages",
         "GlobalReport__getReportPagesByDate",
+        "LocalReport__getQuarterScoreboard",
+        "LocalReport__reportViewOptions",
+        "LocalReport__getReportPages",
     ];
 
     protected $unauthenticatedMethods = [

--- a/src/app/Http/Middleware/TokenAuthenticate.php
+++ b/src/app/Http/Middleware/TokenAuthenticate.php
@@ -5,6 +5,7 @@ use Auth;
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
 use Session;
+use TmlpStats as Models;
 use TmlpStats\ReportToken;
 
 class TokenAuthenticate
@@ -46,6 +47,15 @@ class TokenAuthenticate
                 $user->setReportToken($reportToken);
                 Auth::setUser($user);
 
+                if (!Session::has('timezone')) {
+                    $timezone = 'US/Eastern';
+                    if ($reportToken->ownerType == Models\Region::class) {
+                        //TODO region to timezone mapp
+                    } else if (($report = $reportToken->getReport()) instanceof Models\StatsReport) {
+                        $timezone = $report->center->timezone;
+                    }
+                    Session::set('timezone', $timezone);
+                }
                 Session::set('homePath', $reportToken->getReportPath());
             }
         }

--- a/src/config/reports.yml
+++ b/src/config/reports.yml
@@ -251,6 +251,7 @@ api:
     children:
       getQuarterScoreboard:
         desc: Get scoreboard for all weeks within a quarter
+        access: token
         params:
           - name: localReport
             type: LocalReport
@@ -301,6 +302,7 @@ api:
 
       reportViewOptions:
         desc: View options for report
+        access: token
         params:
           - name: center
             type: Center
@@ -309,6 +311,7 @@ api:
 
       getReportPages:
         desc: Get report pages
+        access: token
         params:
           - name: center
             type: Center


### PR DESCRIPTION
1) Enable token auth for APIs
2) Stop the spamming of the setTimezone call for unauthenticated users.