### PR TITLE
More advanced shim detection using session.

### DIFF
--- a/src/app/Api/UserProfile.php
+++ b/src/app/Api/UserProfile.php
@@ -10,7 +10,7 @@ class UserProfile
         $this->request = $request;
     }
 
-    public function setLocale($locale = "", $timezone = "")
+    public function setLocale($locale = '', $timezone = '')
     {
         // Save the user's timezone
         if ($timezone) {
@@ -22,5 +22,12 @@ class UserProfile
         }
 
         return ['success' => true];
+    }
+
+    public function needsShim($v = '')
+    {
+        Session::set('needs_shim', $v);
+
+        return [];
     }
 }

--- a/src/app/Http/Controllers/ApiController.php
+++ b/src/app/Http/Controllers/ApiController.php
@@ -65,6 +65,7 @@ class ApiController extends ApiControllerBase
         "TeamMember.stash" => "TeamMember__stash",
         "TeamMember.bulkStashWeeklyReporting" => "TeamMember__bulkStashWeeklyReporting",
         "UserProfile.setLocale" => "UserProfile__setLocale",
+        "UserProfile.needsShim" => "UserProfile__needsShim",
         "ValidationData.validate" => "ValidationData__validate",
     ];
 
@@ -75,6 +76,7 @@ class ApiController extends ApiControllerBase
 
     protected $unauthenticatedMethods = [
         "LiveScoreboard__getCurrentScores",
+        "UserProfile__needsShim",
     ];
 
     protected function Admin__Region__getRegion($input)
@@ -414,6 +416,12 @@ class ApiController extends ApiControllerBase
         return App::make(Api\UserProfile::class)->setLocale(
             $this->parse($input, 'locale', 'string'),
             $this->parse($input, 'timezone', 'string')
+        );
+    }
+    protected function UserProfile__needsShim($input)
+    {
+        return App::make(Api\UserProfile::class)->needsShim(
+            $this->parse($input, 'v', 'string')
         );
     }
     protected function ValidationData__validate($input)

--- a/src/config/reports.yml
+++ b/src/config/reports.yml
@@ -478,6 +478,12 @@ api:
             type: string
           - name: timezone
             type: string
+      needsShim:
+        access: any
+        desc: Tell the server we definitely need a shim
+        params:
+          - name: v
+            type: string
 
   ValidationData:
     type: namespace

--- a/src/public/js/detect-shim.js
+++ b/src/public/js/detect-shim.js
@@ -1,0 +1,11 @@
+(function(document) {
+    var needsShim = 'n';
+    if (!Object.assign || !String.prototype.startsWith) {
+        needsShim = 'y';
+        var s = document.createElement('script');
+        s.src = '/vendor/js/shim.min.js';
+        var firstScript = document.getElementsByTagName('script')[0];
+        firstScript.parentNode.insertBefore(s, firstScript);
+    }
+    $.post('/api/UserProfile.needsShim', {v: needsShim}, null, 'json');
+})(document);

--- a/src/resources/assets/js/api/api-generated.js
+++ b/src/resources/assets/js/api/api-generated.js
@@ -439,7 +439,14 @@ Api.UserProfile = {
       locale: string
       timezone: string
     */
-    setLocale: bac('UserProfile.setLocale')
+    setLocale: bac('UserProfile.setLocale'),
+
+    /*
+    Tell the server we definitely need a shim
+    Parameters:
+      v: string
+    */
+    needsShim: bac('UserProfile.needsShim')
 }
 
 Api.ValidationData = {

--- a/src/resources/assets/js/classic/tmlp-polyfill.js
+++ b/src/resources/assets/js/classic/tmlp-polyfill.js
@@ -7,3 +7,7 @@ if (!window.console.log) {
         // does nothing
     }
 }
+
+if (!window.Promise) {
+    require('es6-promise').polyfill()
+}

--- a/src/resources/views/template.blade.php
+++ b/src/resources/views/template.blade.php
@@ -6,7 +6,7 @@ $baseController = App::make(TmlpStats\Http\Controllers\Controller::class);
 $center = $baseController->getCenter(Request::instance());
 $region = $baseController->getRegion(Request::instance());
 $reportingDate = $baseController->getReportingDate();
-
+$needs_shim = Session::get('needs_shim', '');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -25,18 +25,6 @@ $reportingDate = $baseController->getReportingDate();
     <script src="{{ asset('vendor/js/respond.min.js') }}"></script>
     <![endif]-->
 
-    {{-- The ES6 shim brings ES6 functions, but we're doing a detection, most browsers other than IE these days support this without a shim.--}}
-    <script type="text/javascript">
-        if (!Object.assign || !String.prototype.startsWith) {
-            (function(d) {
-                var s = d.createElement('script')
-                s.src = @json(asset('/vendor/js/shim.min.js'));
-                var firstScript = d.getElementsByTagName('script')[0]
-                firstScript.parentNode.insertBefore(s, firstScript)
-            })(document)
-        }
-    </script>
-
     <link href="{{ mix('build/css/app.css') }}" rel="stylesheet">
 
     @yield('headers')
@@ -54,6 +42,13 @@ $reportingDate = $baseController->getReportingDate();
     @endif
 
     @include('partials.settings')
+
+    {{-- The ES6 shim brings ES6 functions, but we're doing a detection, most browsers other than IE these days support this without a shim.--}}
+    @if ($needs_shim == 'y')
+        <script type="text/javascript" src="{{ asset('/vendor/js/shim.min.js') }}"></script>
+    @elseif ($needs_shim != 'n')
+        <script type="text/javascript" src="/js/detect-shim.js"></script>
+    @endif
 
     <script src="{{ mix('build/js/classic-vendor.js') }}" type="text/javascript"></script>
     <script src="{{ mix('build/js/manifest.js') }}" type="text/javascript"></script>

--- a/src/tests/browser/smoke_test.spec.js
+++ b/src/tests/browser/smoke_test.spec.js
@@ -7,6 +7,8 @@
  */
 const vars = require('./vars')
 
+const DEFAULT_WAIT = 10000
+
 describe('Smoke Test', function() {
     it('can perform login', () => {
         browser.windowHandleMaximize('current')
@@ -18,18 +20,20 @@ describe('Smoke Test', function() {
         form.$('[name="email"]').addValue(vars.login.email)
         form.$('[name="password"]').addValue(vars.login.password)
         form.$('input.btn-default').click()
-        browser.pause(2000)
+        browser.pause(1000)
+        $('table').waitForExist(DEFAULT_WAIT)
     })
 
     it('can load new Submission UI', () => {
-        browser.click('=Submit Report (beta)')
+        $('=Submit Report (beta)').click()
+        browser.pause(1000)
         // We wait for the h3 first because it means the content pane is done loading
-        $('h3').waitForExist(10000)
-        $('.submission-nav').waitForExist(10000)
+        $('h3').waitForExist(DEFAULT_WAIT)
+        $('.submission-nav').waitForExist(1000)
     })
 
     it('can switch to Courses Link', () => {
         $('.submission-nav').$('a=Courses').click()
-        $('h3=Manage Courses').waitForExist(5000)
+        $('h3=Manage Courses').waitForExist(DEFAULT_WAIT)
     })
 })


### PR DESCRIPTION
This is needed to get Safari 7,8 to work in addition to IE, since
DOM-added scripts are parsed asynchronously. So after the first time
detecting we need a shim, we set it in the session.