### PR TITLE
Don't double-load review and expire it sensibly

### DIFF
--- a/src/resources/assets/js/reusable/reducers.js
+++ b/src/resources/assets/js/reusable/reducers.js
@@ -1,24 +1,19 @@
 import { objectAssign } from './ponyfill'
 
-const
-    NEW = {state: 'new', loaded: false, available: true},
-    LOADING = {state: 'loading', loaded: false, available: false},
-    LOADED = {state: 'loaded', loaded: true, available: true},
-    FAILED = {state: 'failed', loaded: false, failed: true, available: false}
+const loadStates = {
+    new: {state: 'new', loaded: false, available: true},
+    loading: {state: 'loading', loaded: false, available: false},
+    loaded: {state: 'loaded', loaded: true, available: true},
+    failed: {state: 'failed', loaded: false, failed: true, available: false}
+}
 
 export function loadingMultiState(actionType) {
-    return function(state = NEW, action){
+    return function(state = loadStates['new'], action){
         if (action.type == actionType) {
-            switch (action.payload) {
-            case 'loading':
-                return LOADING
-            case 'loaded':
-                return LOADED
-            case 'failed':
-                return FAILED
-            case 'new':
-                return NEW
-            default:
+            // toUpperase check proves this is a string
+            if (action.payload.toUpperCase) {
+                return loadStates[action.payload]
+            } else {
                 return action.payload
             }
         }
@@ -27,7 +22,7 @@ export function loadingMultiState(actionType) {
 }
 
 export class LoadingMultiState {
-    static states = {NEW, LOADING, LOADED, FAILED}
+    static states = loadStates
 
     constructor(actionType) {
         this.actionType = actionType
@@ -35,9 +30,11 @@ export class LoadingMultiState {
 
     actionCreator() {
         const actionType = this.actionType
-        return (newState) => {
+        return (newState, extra) => {
             if (newState.error) {
-                newState = objectAssign({}, FAILED, newState)
+                newState = objectAssign({}, loadStates.failed, newState)
+            } else if (extra) {
+                newState = objectAssign({}, loadStates[newState], extra)
             }
             return {type: actionType, payload: newState}
         }

--- a/src/resources/assets/js/reusable/redux_loader/base.js
+++ b/src/resources/assets/js/reusable/redux_loader/base.js
@@ -16,9 +16,7 @@ export const LOADER_DEFAULT_OPTS = {
     successHandler: (data, {loader}) =>{
         return loader.replaceCollection(data)
     },
-    failHandler: (err) =>{
-        throw err
-    }
+    failHandler: (err) => null
 }
 
 const SET_METADATA = 'loader/setMetadata'
@@ -123,7 +121,7 @@ export class ReduxLoader {
                     dispatch(result)
                 }
                 if (actionData.setLoaded && !actionData.inGroup) {
-                    dispatch(loadAction('loaded'))
+                    dispatch(loadAction(fixedErr))
                 }
             }
 

--- a/src/resources/assets/js/submission/applications/actions.js
+++ b/src/resources/assets/js/submission/applications/actions.js
@@ -7,6 +7,7 @@ import { scrollIntoView } from '../../reusable/ui_basic'
 import Api from '../../api'
 
 import { appsCollection, applicationsLoad, saveAppLoad, messages } from './data'
+import { markStale } from '../review/actions'
 
 export const loadState = applicationsLoad.actionCreator()
 export const saveAppState = saveAppLoad.actionCreator()
@@ -30,8 +31,7 @@ export function loadApplications(centerId, reportingDate) {
             dispatch(initializeApplications(data))
             return data
         }).catch((err) => {
-            console.log(err)
-            dispatch(loadState('failed'))
+            dispatch(loadState({error: err.error || 'error'}))
         })
     }
 }
@@ -60,6 +60,7 @@ export function saveApplication(center, reportingDate, data) {
         return Api.Application.stash({
             center, reportingDate, data
         }).then((result) => {
+            dispatch(markStale())
             // Failed during validation
             if (!result.storedId) {
                 dispatch(messages.replace('create', result.messages))

--- a/src/resources/assets/js/submission/core/checkCoreData.js
+++ b/src/resources/assets/js/submission/core/checkCoreData.js
@@ -1,5 +1,5 @@
 import { delayDispatch } from '../../reusable/dispatch'
-import { getValidationMessages } from '../review/actions'
+import { getValidationMessagesIfStale } from '../review/actions'
 
 import * as actions from './actions'
 
@@ -10,7 +10,7 @@ export default function checkCoreData(centerId, reportingDate, core, dispatch) {
     } else if (core.coreInit.state == 'new') {
         delayDispatch(dispatch,
             actions.initSubmission(centerId, reportingDate),
-            getValidationMessages(centerId, reportingDate),
+            getValidationMessagesIfStale(centerId, reportingDate),
         )
         return false
     } else if (core.coreInit.state != 'loaded') {

--- a/src/resources/assets/js/submission/courses/actions.js
+++ b/src/resources/assets/js/submission/courses/actions.js
@@ -5,6 +5,8 @@ import { getMessages } from '../../reusable/ajax_utils'
 import { objectAssign } from '../../reusable/ponyfill'
 import { scrollIntoView } from '../../reusable/ui_basic'
 import Api from '../../api'
+import { markStale } from '../review/actions'
+
 import { coursesCollection, coursesLoad, saveCourseLoad, messages } from './data'
 
 export const loadState = coursesLoad.actionCreator()
@@ -50,6 +52,7 @@ export function saveCourse(center, reportingDate, data) {
         return Api.Course.stash({
             center, reportingDate, data
         }).then((result) => {
+            dispatch(markStale())
             // Failed during validation
             if (!result.storedId) {
                 dispatch(messages.replace('create', result.messages))

--- a/src/resources/assets/js/submission/review/actions.js
+++ b/src/resources/assets/js/submission/review/actions.js
@@ -1,16 +1,19 @@
 import Api from '../../api'
 import { PAGES_CONFIG } from '../core/data'
 import { MessageManager } from '../../reusable/reducers'
-import { reportSubmitting, displayFlow, DISPLAY_STATES } from './data'
+import { reportSubmitting, displayFlow, reviewLoaded, DISPLAY_STATES } from './data'
 
 // bogusManager is used to cheat on dispatching to all the other MessageManager(s) all over the codebase
 const bogusManager = new MessageManager('bogus')
 
 export const submitState = reportSubmitting.actionCreator()
 export const displayState = displayFlow.actionCreator()
+const loadState = reviewLoaded.actionCreator()
+const STALE_TIMEOUT = 180 * 1000 // 3min(180 seconds) for validation messages to be stale.
 
 export function getValidationMessages(center, reportingDate) {
     return (dispatch) => {
+        dispatch(loadState('loading'))
         return Api.ValidationData.validate({center, reportingDate}).then((data) => {
             dispatch(setMessages(data.messages))
             PAGES_CONFIG.forEach((config) => {
@@ -29,8 +32,42 @@ export function getValidationMessages(center, reportingDate) {
                     dispatch(bogusManager.replaceAll(keyedMessages, config.key))
                 }
             })
+            dispatch(loadState('loaded', {timestamp: Date.now()}))
             return data
+        }).catch((err) => {
+            dispatch(loadState({error: err.error || 'error'}))
         })
+    }
+}
+
+// This thunk action has two functions:
+// 1) Prevents getting validation messages twice due to being triggered multiple places
+// 2) Also prevents getting messages on tab switches if messages are not stale
+export function getValidationMessagesIfStale(center, reportingDate) {
+    return (dispatch, getState) => {
+        let checkNum = 0
+        function check() {
+            let current = reviewLoaded.selector(getState())
+            if (!current.available) {
+                return // Nothing to do if we're loading already or failed
+            } else if (++checkNum < 2) {
+                // This countdown is done because it's possible for simultaneous dispatch
+                // to cause two different checks to observe validation messages as stale.
+                setTimeout(check, 1)
+            } else if (current.state == 'new' || (current.timestamp + STALE_TIMEOUT) < Date.now()) {
+                dispatch(getValidationMessages(center, reportingDate))
+            }
+        }
+        check()
+    }
+}
+
+export function markStale() {
+    return (dispatch, getState) => {
+        let current = reviewLoaded.selector(getState())
+        if (current.timestamp) {
+            dispatch(loadState('loaded', {timestamp: 0}))
+        }
     }
 }
 

--- a/src/resources/assets/js/submission/review/components.jsx
+++ b/src/resources/assets/js/submission/review/components.jsx
@@ -8,7 +8,7 @@ import { Form } from '../../reusable/form_utils'
 import { Alert, ButtonStateFlip } from '../../reusable/ui_basic'
 import { SubmissionBase, React } from '../base_components'
 
-import { getValidationMessages, displayState, submitReport, submitState, setSubmitData } from './actions'
+import { getValidationMessagesIfStale, displayState, submitReport, submitState, setSubmitData } from './actions'
 import { DISPLAY_STATES } from './data'
 import { REVIEW_SUBMIT_FORM_KEY } from './reducers'
 
@@ -22,7 +22,7 @@ export default class Review extends SubmissionBase {
 
     static onRouteEnter(nextState) {
         const { store } = require('../../store')
-        store.dispatch(getValidationMessages(nextState.params.centerId, nextState.params.reportingDate))
+        store.dispatch(getValidationMessagesIfStale(nextState.params.centerId, nextState.params.reportingDate))
     }
 
     constructor(props) {
@@ -84,7 +84,7 @@ export default class Review extends SubmissionBase {
             return this.renderBasicLoading()
         }
 
-        const { submitResults, displayFlow, reportSubmitting } = this.props.review
+        const { submitResults, displayFlow, reportSubmitting, loaded } = this.props.review
 
         if (displayFlow.state == DISPLAY_STATES.preSubmit) {
             return (
@@ -121,9 +121,15 @@ export default class Review extends SubmissionBase {
             }
         })
 
+        let fetching
+        if (loaded.state == 'loading') {
+            fetching = <p className="lead">Fetching updated messages....</p>
+        }
+
         return (
             <div>
                 <h3>Review</h3>
+                {fetching}
                 <ul>{categories}</ul>
                 <div>
                     <Alert alert="warning">&nbsp;Submission is new and we are still adding the finishing touches. Let us know using the "Feedback" tab on the left if anything doesn't look right.</Alert>
@@ -215,7 +221,7 @@ export class ReviewCategory extends React.PureComponent {
 
         return (
             <div>
-                <h3>{config.name}</h3>
+                <h4>{config.name}</h4>
                 <ul>{messages}</ul>
             </div>
         )

--- a/src/resources/assets/js/submission/review/data.js
+++ b/src/resources/assets/js/submission/review/data.js
@@ -3,3 +3,6 @@ import { LoadingMultiState } from '../../reusable/reducers'
 export const reportSubmitting = new LoadingMultiState('review/submitReport')
 export const displayFlow = new LoadingMultiState('review/displayFlow')
 export const DISPLAY_STATES = {main: 'new', preSubmit: 'loading', postSubmit: 'loaded'}
+
+export const reviewLoaded = new LoadingMultiState('review/loaded')
+reviewLoaded.selector = (state) => state.submission.review.loaded

--- a/src/resources/assets/js/submission/review/reducers.js
+++ b/src/resources/assets/js/submission/review/reducers.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux'
 import { modelReducer, formReducer } from 'react-redux-form'
-import { reportSubmitting, displayFlow } from './data'
+import { reportSubmitting, displayFlow, reviewLoaded } from './data'
 
 export const REVIEW_SUBMIT_FORM_KEY = 'submission.review.submitData'
 
@@ -20,6 +20,7 @@ function submitResultReducer(state=null, action) {
 
 export default combineReducers({
     oldMessages: messagesReducer,
+    loaded: reviewLoaded.reducer(),
     submitData: modelReducer(REVIEW_SUBMIT_FORM_KEY),
     submitDataForm: formReducer(REVIEW_SUBMIT_FORM_KEY),
     submitResults: submitResultReducer,

--- a/src/resources/assets/js/submission/scoreboard/actions.js
+++ b/src/resources/assets/js/submission/scoreboard/actions.js
@@ -1,6 +1,8 @@
 import { actions as formActions } from 'react-redux-form'
 
 import Api from '../../api'
+import { markStale } from '../review/actions'
+
 import { SCOREBOARDS_FORM_KEY, SCOREBOARD_SAVED, scoreboardLoad, scoreboardSave, annotateScoreboards, messages } from './data'
 
 export const loadState = scoreboardLoad.actionCreator()
@@ -44,6 +46,7 @@ export function saveScoreboards(centerId, reportingDate, toSaveItems, scoreboard
                 dispatch(scoreboardSaved(candidate))
                 dispatch(messages.replace(data.week, data.messages))
                 dispatch(saveState('loaded'))
+                dispatch(markStale())
             } else {
                 throw data
             }

--- a/src/resources/assets/js/submission/scoreboard/components.jsx
+++ b/src/resources/assets/js/submission/scoreboard/components.jsx
@@ -14,16 +14,15 @@ import { SubmissionBase } from '../base_components'
 import { loadScoreboard, saveScoreboards } from './actions'
 import { SCOREBOARDS_FORM_KEY } from './data'
 
-import { getValidationMessages } from '../review/actions'
+import { getValidationMessagesIfStale } from '../review/actions'
 
 /**
  * SubmissionScoreboard is the root component for rendering the scoreboard view.
  */
 class SubmissionScoreboard extends SubmissionBase {
-
     static onRouteEnter(nextState) {
         const { store } = require('../../store')
-        store.dispatch(getValidationMessages(nextState.params.centerId, nextState.params.reportingDate))
+        store.dispatch(getValidationMessagesIfStale(nextState.params.centerId, nextState.params.reportingDate))
     }
 
     constructor(props) {

--- a/src/resources/assets/js/submission/team_members/actions.js
+++ b/src/resources/assets/js/submission/team_members/actions.js
@@ -4,6 +4,7 @@ import { actions as formActions } from 'react-redux-form'
 import { getMessages } from '../../reusable/ajax_utils'
 import { objectAssign } from '../../reusable/ponyfill'
 import Api from '../../api'
+import { markStale } from '../review/actions'
 
 import { teamMembersData, weeklyReportingData, weeklyReportingSave, messages } from './data'
 import { TEAM_MEMBERS_COLLECTION_FORM_KEY, TEAM_MEMBER_FORM_KEY } from './reducers'
@@ -56,6 +57,7 @@ export function weeklyReportingSubmit(center, reportingDate, tracking, rawData) 
         dispatch(weeklySaveState('loading'))
 
         const success = (data) => {
+            dispatch(markStale())
             dispatch(weeklySaveState('loaded'))
             if (data && data.messages) {
                 dispatch(messages.replaceMany(data.messages))
@@ -82,6 +84,7 @@ export function setExitChoice(exitChoice) {
 export function stashTeamMember(center, reportingDate, data) {
     return teamMembersData.runNetworkAction('save', {center, reportingDate, data}, {
         successHandler(result, { dispatch }) {
+            dispatch(markStale())
             // The request failed before creating an id (parser error)
             if (!result.storedId) {
                 dispatch(teamMembersData.saveState({error: 'Validation Failed', messages: result.messages}))

--- a/src/resources/assets/js/tests/reusable/ui_basic.test.jsx
+++ b/src/resources/assets/js/tests/reusable/ui_basic.test.jsx
@@ -28,7 +28,7 @@ test('LoadStateFlip', () => {
     const states = LoadingMultiState.states
 
     const tree = renderer.create(
-        <LoadStateFlip loadState={states.LOADING}>
+        <LoadStateFlip loadState={states.loading}>
             <div>Will never be seen</div>
         </LoadStateFlip>
     ).toJSON()
@@ -36,7 +36,7 @@ test('LoadStateFlip', () => {
     expect(tree.children[1]).toMatch(/spinner/)
 
     const tree2 = renderer.create(
-        <LoadStateFlip loadState={states.LOADED}>
+        <LoadStateFlip loadState={states.loaded}>
             <div className="foo">HELLO</div>
         </LoadStateFlip>
     ).toJSON()


### PR DESCRIPTION
Whenever you loaded the 'review' page, it would always run the review
endpoint twice. This fixes this plus adds the following features:

* Adds an action which only loads review if considered stale
* Sets a timeout after which 'review' information is considered stale
* Save actions from all across the submission core will trigger staleness.

In addition, the following minor changes:
* LoadingMultiState now supports storing additional keys for special
  cases if needed