### PR TITLE
Allow regionals to not send submission email

### DIFF
--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -436,10 +436,12 @@ class SubmissionCore extends AuthenticatedApiBase
         $success = true;
         DB::commit();
 
-        $emailResults = "<strong>Thank you.</strong> We received your statistics and did not send notification emails.";
-        if (!array_get($data, 'skipSubmitEmail', false) || !$this->context->can('skipSubmitEmail', $center)) {
+        if (array_get($data, 'skipSubmitEmail', false) && $this->context->can('skipSubmitEmail', $center)) {
+            $emailResults = "<strong>Thank you.</strong> We received your statistics and did not send notification emails.";
+        } else {
             $emailResults = $this->sendStatsSubmittedEmail($statsReport);
         }
+
         $submittedAt = $statsReport->submittedAt->copy()->setTimezone($center->timezone);
 
         return [

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -51,9 +51,12 @@ class SubmissionCore extends AuthenticatedApiBase
         $accountabilities = Models\Accountability::orderBy('name')->get();
         $centers = Models\Center::byRegion($center->getGlobalRegion())->active()->orderBy('name')->get();
 
+        $canSkipSubmitEmail = $this->context->can('skipSubmitEmail', $center);
+
         return [
             'success' => true,
             'id' => $center->id,
+            'user' => compact('canSkipSubmitEmail'),
             'validRegQuarters' => $validRegQuarters,
             'validStartQuarters' => $validStartQuarters,
             'lookups' => compact('withdraw_codes', 'team_members', 'center', 'centers'),
@@ -433,7 +436,10 @@ class SubmissionCore extends AuthenticatedApiBase
         $success = true;
         DB::commit();
 
-        $emailResults = $this->sendStatsSubmittedEmail($statsReport);
+        $emailResults = "<strong>Thank you.</strong> We received your statistics and did not send notification emails.";
+        if (!array_get($data, 'skipSubmitEmail', false)) {
+            $emailResults = $this->sendStatsSubmittedEmail($statsReport);
+        }
         $submittedAt = $statsReport->submittedAt->copy()->setTimezone($center->timezone);
 
         return [

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -437,7 +437,7 @@ class SubmissionCore extends AuthenticatedApiBase
         DB::commit();
 
         $emailResults = "<strong>Thank you.</strong> We received your statistics and did not send notification emails.";
-        if (!array_get($data, 'skipSubmitEmail', false)) {
+        if (!array_get($data, 'skipSubmitEmail', false) || !$this->context->can('skipSubmitEmail', $center)) {
             $emailResults = $this->sendStatsSubmittedEmail($statsReport);
         }
         $submittedAt = $statsReport->submittedAt->copy()->setTimezone($center->timezone);

--- a/src/app/Policies/CenterPolicy.php
+++ b/src/app/Policies/CenterPolicy.php
@@ -50,6 +50,11 @@ class CenterPolicy extends Policy
         return false;
     }
 
+    public function skipSubmitEmail(User $user, Center $center)
+    {
+        return $user->hasRole('globalStatistician');
+    }
+
     public function adminScoreboard(User $user, Center $center)
     {
         return ($user->hasRole('globalStatistician'));

--- a/src/resources/assets/js/submission/core/actions.js
+++ b/src/resources/assets/js/submission/core/actions.js
@@ -46,6 +46,8 @@ export function setSubmissionLookups(data, reportingDate) {
             lookups.team_members = lookups.team_members.sort((a, b) => getLabelTeamMember(a).localeCompare(getLabelTeamMember(b)))
         }
 
+        lookups.user = c.user
+
         /// Precompute items like pastClassroom based on quarter dates.
         if (data.currentQuarter) {
             reportingDate = moment(reportingDate)

--- a/src/resources/assets/js/submission/review/components.jsx
+++ b/src/resources/assets/js/submission/review/components.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router'
 import { PAGES_CONFIG } from '../core/data'
 import { connectRedux, rebind } from '../../reusable/dispatch'
 import { Field } from 'react-redux-form'
-import { Form } from '../../reusable/form_utils'
+import { CheckBox, Form } from '../../reusable/form_utils'
 import { Alert, ButtonStateFlip } from '../../reusable/ui_basic'
 import { SubmissionBase, React } from '../base_components'
 
@@ -88,7 +88,8 @@ export default class Review extends SubmissionBase {
             return (
                 <PreSubmitCard dismiss={this.hidePreSubmitModal}
                                onSubmit={this.onSubmit}
-                               loadState={reportSubmitting} />
+                               loadState={reportSubmitting}
+                               lookups={this.props.core.lookups} />
             )
         }
 
@@ -228,7 +229,13 @@ export class ReviewCategory extends React.PureComponent {
 
 class PreSubmitCard extends React.PureComponent {
     render() {
-        const { dismiss, onSubmit, loadState } = this.props
+        const { dismiss, onSubmit, loadState, lookups } = this.props
+        const modelKey = REVIEW_SUBMIT_FORM_KEY
+
+        let skipEmailCheckbox
+        if (lookups.user.canSkipSubmitEmail) {
+            skipEmailCheckbox = <CheckBox label="Don't send submission email" model={modelKey+'.skipSubmitEmail'} />
+        }
 
         return (
             <div>
@@ -245,8 +252,9 @@ class PreSubmitCard extends React.PureComponent {
                     </ul>
                     You can re-submit your stats before 7PM your local time on Friday.
                     <br/><br/>
-                    <Form model={REVIEW_SUBMIT_FORM_KEY} onSubmit={onSubmit}>
-                        <Field model={REVIEW_SUBMIT_FORM_KEY+'.comment'}>
+                    <Form model={modelKey} onSubmit={onSubmit}>
+                        {skipEmailCheckbox}
+                        <Field model={modelKey+'.comment'}>
                             <div className="form-group">
                                 <label htmlFor="comment" className="control-label">Comment:</label>
                                 <textarea name="comment" className="form-control" rows="10" />


### PR DESCRIPTION
Adds a checkbox to first submit card to indicate that the submission email shouldn't be sent. Only displays for regionals and admins