### PR TITLE
Use overriden center dates when building Center Games report

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -434,6 +434,7 @@ class StatsReportController extends Controller
         $a = new Arrangements\GamesByMilestone([
             'weeks' => App::make(Api\LocalReport::class)->getQuarterScoreboard($statsReport),
             'quarter' => $statsReport->quarter,
+            'center' => $statsReport->center,
         ]);
         $data = $a->compose();
 

--- a/src/app/Reports/Arrangements/GamesByMilestone.php
+++ b/src/app/Reports/Arrangements/GamesByMilestone.php
@@ -1,6 +1,8 @@
-<?php namespace TmlpStats\Reports\Arrangements;
+<?php
+namespace TmlpStats\Reports\Arrangements;
 
 use Carbon\Carbon;
+use TmlpStats\Domain;
 
 class GamesByMilestone extends BaseArrangement
 {
@@ -15,15 +17,27 @@ class GamesByMilestone extends BaseArrangement
     {
         $weeks = $data['weeks'];
         $quarter = $data['quarter'];
+        $center = isset($data['center']) ? $data['center'] : null;
+
+        if ($center) {
+            $centerQuarter = Domain\CenterQuarter::ensure($center, $quarter);
+            $classroom1Date = $centerQuarter->classroom1Date;
+            $classroom2Date = $centerQuarter->classroom2Date;
+            $classroom3Date = $centerQuarter->classroom3Date;
+        } else {
+            $classroom1Date = $quarter->getClassroom1Date();
+            $classroom2Date = $quarter->getClassroom2Date();
+            $classroom3Date = $quarter->getClassroom3Date();
+        }
 
         $reportData = [];
         foreach ($weeks as $dateString => $weekData) {
             $weekDate = Carbon::createFromFormat('Y-m-d', $dateString)->startOfDay();
-            if ($weekDate->lte($quarter->getClassroom1Date())) {
+            if ($weekDate->lte($classroom1Date)) {
                 $classroom = 0;
-            } else if ($weekDate->lte($quarter->getClassroom2Date())) {
+            } else if ($weekDate->lte($classroom2Date)) {
                 $classroom = 1;
-            } else if ($weekDate->lte($quarter->getClassroom3Date())) {
+            } else if ($weekDate->lte($classroom3Date)) {
                 $classroom = 2;
             } else {
                 $classroom = 3;


### PR DESCRIPTION
Fix issue where center's overridden quarter dates aren't used when building Center Games report