### PR TITLE
Better Center Report 404s:

### DIFF
--- a/src/app/Http/Controllers/ReportsController.php
+++ b/src/app/Http/Controllers/ReportsController.php
@@ -259,11 +259,19 @@ class ReportsController extends Controller
                 return App::make($controllerClass)->showForRegion($request, $report, $reportTarget);
             }
         } else {
+            $controller = App::make(StatsReportController::class);
+
             $report = StatsReport::byCenter($reportTarget)
                 ->reportingDate($reportingDate)
                 ->official()
-                ->firstOrFail();
-            $redirectUrl = App::make(StatsReportController::class)->getUrl($report);
+                ->first();
+
+            // Find a report from a previous week
+            if ($report === null) {
+                return $controller->showReportChooser($request, $reportTarget, $reportingDate);
+            }
+
+            $redirectUrl = $report->getUriLocalReport();
 
             $this->setCenter($report->center);
         }

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -129,6 +129,33 @@ class StatsReportController extends Controller
         ));
     }
 
+    public function showReportChooser(Request $request, Models\Center $center, Carbon $reportingDate)
+    {
+
+        $crd = Encapsulations\CenterReportingDate::ensure($center, $reportingDate);
+        $cq = $crd->getCenterQuarter();
+
+        // candidates are reporting dates in reverse, but only those which are before this reporting date.
+        $dates = collect($cq->listReportingDates())->reverse()->filter(function ($d) use ($reportingDate) {
+            return $d->lt($reportingDate);
+        });
+
+        foreach ($dates as $d) {
+            $maybeReport = Models\StatsReport::byCenter($center)
+                ->reportingDate($d)
+                ->official()
+                ->first();
+            if ($maybeReport !== null) {
+                break;
+            }
+        }
+
+        return view('statsreports.report_chooser', compact(
+            'reportingDate',
+            'maybeReport'
+        ));
+    }
+
     protected function getSheetPathUrl($statsReport)
     {
         $sheetPath = XlsxArchiver::getInstance()->getSheetPath($statsReport);

--- a/src/resources/views/statsreports/report_chooser.blade.php
+++ b/src/resources/views/statsreports/report_chooser.blade.php
@@ -1,0 +1,29 @@
+@extends('template')
+@inject('context', 'TmlpStats\Api\Context')
+@section('content')
+    <h1>Report Not Found</h1>
+
+    <div id="content">
+        We couldn't find a report for <b>{{ $reportingDate->toDateString() }}</b>
+
+        @if ($maybeReport)
+            <p>
+                However, we do have a report for <b>{{ $maybeReport->reportingDate->toDateString() }}</b>
+            </p>
+            <p>
+                <a href="{{ $maybeReport->getUriLocalReport() }}" class="btn btn-lg btn-default">Click Here</a>
+            </div>
+        @endif
+    </div>
+
+@endsection
+
+@section('scripts')
+@if ($maybeReport)
+    <script type="text/javascript">
+        setTimeout(function() {
+            document.location.href = @json($maybeReport->getUriLocalReport());
+        }, 3000);
+    </script>
+@endif
+@endsection


### PR DESCRIPTION
Frequently now (with online submission) we link people to a center
report for a global report which exists, but for which there is not
yet a center report (because some centers/regions have already
submitted and others have not)

This puts in the beginnings of a simple report chooser to show on the
404 page, so that we can help the user out, and default redirect.