### PR TITLE
Handle missing regDate in UI since we allow stashing it

### DIFF
--- a/src/resources/assets/js/submission/applications/AppStatus.jsx
+++ b/src/resources/assets/js/submission/applications/AppStatus.jsx
@@ -37,7 +37,9 @@ function inferStatus(app) {
         return STATUS_REG
     }
 
-    return STATUS_UNKNOWN
+    // Default to reg if something isn't right
+    console.log(`Unknown application status for ${app.id}`)
+    return STATUS_REG
 }
 
 function inferWithdrawn(app) {
@@ -61,7 +63,7 @@ export function getStatusString(app) {
         return o.status == statusCode
     })
 
-    return status.title
+    return status ? status.title : 'Invalid'
 }
 
 export default class AppStatus extends Component {

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -28,11 +28,6 @@ const sharedMapState = (state) => {
 }
 
 class ApplicationsBase extends SubmissionBase {
-    constructor(props) {
-        super(props)
-        this.checkLoading()
-    }
-
     checkLoading() {
         const { loading, params } = this.props
         if (loading.state == 'new') {
@@ -282,7 +277,7 @@ class _EditCreate extends ApplicationsBase {
         } else {
             const clickHandler = () => {
                 this.props.dispatch(formActions.change(`${modelKey}.${CHANGING_QUARTER_KEY}`, true))
-                return false; // prevent navigation to hash URL
+                return false // prevent navigation to hash URL
             }
             const cq = cqData[currentApp.incomingQuarter]
             const label = (cq)? centerQuarterData.getLabel(cq) : 'Unknown'


### PR DESCRIPTION
We allow stashing invalid data to an existing object. If someone stashes an application without a regDate, it breaks the UI. Fix by defaulting to registered which will show the fields needed to fix it.

Also, remove checkLoading from ApplicationBase to prevent double loading the application list