### PR TITLE
Takeover straggler accountabilities

### DIFF
--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -104,8 +104,11 @@ class SubmissionCore extends AuthenticatedApiBase
 
             $lastStatsReportDate = $reportingDate->copy()->subWeek();
 
+            // Report is as of 3PM on Friday (technically this should be center time)
             $reportNow = $reportingDate->copy()->setTime(15, 0, 0);
-            $quarterEndDate = $statsReport->quarter->getQuarterEndDate($statsReport->center)->setTime(14, 59, 59);
+            // Quarter is over (for accountables) at 12pm on Saturday at the weekend
+            // It's not Friday at 3pm because we want people to still appear as accountable on the final report
+            $quarterEndDate = $statsReport->quarter->getQuarterEndDate($statsReport->center)->addDay()->setTime(12, 00, 00);
 
             $isFirstWeek = $statsReport->reportingDate->eq($statsReport->quarter->getFirstWeekDate($statsReport->center));
 

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -510,9 +510,8 @@ class SubmissionCore extends AuthenticatedApiBase
                 }
 
                 // If the person doesn't already have this accountability, add it and remove previous holder
-                if (!$person->hasAccountability($accountability, $reportNow)) {
-                    $person->takeoverAccountability($accountability, $reportNow, $quarterEndDate);
-                }
+                // Always call takeover to cleanup any stragglers (leftover from spreadsheet migration)
+                $person->takeoverAccountability($accountability, $reportNow, $quarterEndDate);
             }
 
             // Mark stats report as 'official'

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -38,9 +38,8 @@ class TeamMember extends AuthenticatedApiBase
             $includeData = ($lastReport->reportingDate->eq($reportingDate));
             $options = [
                 'ignore' => ($includeData) ? false : self::$omitGitwTdo,
-                // setting time explicitely here to make sure we display accountabiles up to the time this report is active
-                // 58 instead of 59 because we have an off-by-one error with these expirations
-                'accountabilitiesFor' => $reportingDate->copy()->setTime(14,59,58),
+                // setting time explicitly here to make sure we display accountabiles up to the time this report is active
+                'accountabilitiesFor' => $reportingDate->copy()->setTime(15,0,0),
             ];
             foreach (App::make(LocalReport::class)->getClassList($lastReport) as $tmd) {
                 // it's a small optimization, but prevent creating domain if we have an existing SubmissionData version

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -36,7 +36,12 @@ class TeamMember extends AuthenticatedApiBase
         if ($lastReport) {
             // If the last report happens to be the same week as this week, we can include GITW/TDO.
             $includeData = ($lastReport->reportingDate->eq($reportingDate));
-            $options = ['ignore' => ($includeData) ? false : self::$omitGitwTdo, 'accountabilitiesFor' => $reportingDate];
+            $options = [
+                'ignore' => ($includeData) ? false : self::$omitGitwTdo,
+                // setting time explicitely here to make sure we display accountabiles up to the time this report is active
+                // 58 instead of 59 because we have an off-by-one error with these expirations
+                'accountabilitiesFor' => $reportingDate->copy()->setTime(14,59,58),
+            ];
             foreach (App::make(LocalReport::class)->getClassList($lastReport) as $tmd) {
                 // it's a small optimization, but prevent creating domain if we have an existing SubmissionData version
                 if (!array_key_exists($tmd->teamMemberId, $allTeamMembers)) {

--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -215,7 +215,7 @@ class Person extends Model
                 ap.accountability_id = ?
                 AND p.center_id = ?
                 AND (ap.ends_at IS NULL OR ap.ends_at > ?)',
-            [$starts->copy()->subSecond(), $accountability->id, $this->center->id, $starts]
+            [$starts, $accountability->id, $this->center->id, $starts]
         );
 
         // Add accountability


### PR DESCRIPTION
Takeover accountabilities each week, even if person already has accountability. This helps fix data issues carried over from spreadsheets.

Change default accountability end date to 12pm on Saturday at the weekend. This make sure that the outgoing accountables appear on the final report

Fix off-by-one error. Accountabilities end at the start of the reporting period (3pm Friday), instead of 1 second before. Since we use an exclusive check of ends_at (as opposed to an inclusive check), this fixes the missing second issue.