### PR TITLE
Remove date from home route

### DIFF
--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -40,12 +40,8 @@ class HomeController extends Controller
         }
     }
 
-    public function home(Request $request, $abbr, $date = null)
+    public function home(Request $request, $abbr)
     {
-        if ($date) {
-            // yuck, going back and forth on date, but we'll deal for now.
-            $this->setReportingDate(Carbon::parse($date));
-        }
         $region = Region::abbreviation($abbr)->firstorFail();
         return $this->regionOverview($request, $region);
     }

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -72,7 +72,7 @@ Route::get('import', 'ImportController@indexImportSheet');
 Route::post('import', 'ImportController@importSheet');
 
 Route::match(['get', 'post'], 'home', 'HomeController@index');
-Route::match(['get', 'post'], 'home/{abbr}/{date?}', 'HomeController@home');
+Route::match(['get', 'post'], 'home/{abbr}', 'HomeController@home');
 
 Route::get('/', 'WelcomeController@index');
 


### PR DESCRIPTION
This fixes an annoying exception we keep seeing because someone bookmarked a bad link.

We don't need to support direct linking to a date in the home controller. 