### PR TITLE
Show text 'Last Initial' instead of Last Name

### DIFF
--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -227,7 +227,7 @@ class _EditCreate extends ApplicationsBase {
                 <Form className="form-horizontal" model={modelKey} onSubmit={this.saveAppData.bind(this)}>
                     {this.renderStartingQuarter(modelKey)}
                     <SimpleField label="First Name" model={modelKey+'.firstName'} divClass="col-md-6" required={true} />
-                    <SimpleField label="Last Name" model={modelKey+'.lastName'} divClass="col-md-6" required={true} />
+                    <SimpleField label="Last Initial" model={modelKey+'.lastName'} divClass="col-md-6" required={true} />
                     <SimpleFormGroup label="Team Year" divClass="col-md-4" required={true}>
                         <Control.select model={modelKey+'.teamYear'} className="form-control" style={{maxWidth: '10em'}}>
                             <option value="1">Team 1</option>

--- a/src/resources/assets/js/submission/team_members/components-add-edit.jsx
+++ b/src/resources/assets/js/submission/team_members/components-add-edit.jsx
@@ -83,7 +83,7 @@ class _EditCreate extends TeamMembersBase {
         return (
             <div>
                 <SimpleField label="First Name" model={modelKey+'.firstName'} divClass="col-md-6" disabled={disableBasicInfo} required={!disableBasicInfo} />
-                <SimpleField label="Last Name" model={modelKey+'.lastName'} divClass="col-md-6" disabled={disableBasicInfo} required={!disableBasicInfo} />
+                <SimpleField label="Last Initial" model={modelKey+'.lastName'} divClass="col-md-6" disabled={disableBasicInfo} required={!disableBasicInfo} />
                 <SimpleField label="Email" model={modelKey+'.email'} divClass="col-md-8" controlProps={{type: 'email'}} />
                 <SimpleField label="Phone" model={modelKey+'.phone'} divClass="col-md-6" disabled={disableBasicInfo} />
                 <SimpleFormGroup label="Accountabilities">


### PR DESCRIPTION
Show the text 'Last Initial' instead of 'Last Name' to avoid all the swirl until we can fix the reports to truncate last names