### PR TITLE
Fix incorrect quarter numbers showing up on class list

### DIFF
--- a/src/app/Domain/TeamMember.php
+++ b/src/app/Domain/TeamMember.php
@@ -181,7 +181,8 @@ class TeamMember extends ParserDomain
     {
         $member = parent::fromArray($input, $requiredParams);
 
-        if (!$member->quarterNumber && $member->incomingQuarter && $member->center) {
+        if ($member->incomingQuarter && $member->center) {
+            // Ignore what we stashed, this is an ephemeral convenience value
             $member->quarterNumber = Models\TeamMember::getQuarterNumber($member->incomingQuarter, $member->center->region);
         }
 


### PR DESCRIPTION
We stash it because it's passed down to the front end, but we should recalculate it each time since the stash isn't the source of truth.