### PR TITLE
Allow getReportPages to return partial results.

### DIFF
--- a/src/app/Api/GlobalReport.php
+++ b/src/app/Api/GlobalReport.php
@@ -243,6 +243,7 @@ class GlobalReport extends AuthenticatedApiBase
         $output = [];
         $ckBase = "{$report->id}{$region->id}";
         $controller = App::make(Controllers\GlobalReportController::class);
+        $begin = time();
         foreach ($pages as $page) {
             $f = function () use ($page, $report, $region, $controller) {
                 $response = $controller->newDispatch($page, $report, $region);
@@ -259,6 +260,11 @@ class GlobalReport extends AuthenticatedApiBase
             }
 
             $output[$page] = $response;
+            // If we exceed 8 seconds, return what we have so far to the user.
+            // This allows better responsiveness to tab switching.
+            if ((time() - $begin) >= 8) {
+                break;
+            }
         }
 
         return ['pages' => $output];

--- a/src/resources/assets/js/reports/tabbed_report/manager.js
+++ b/src/resources/assets/js/reports/tabbed_report/manager.js
@@ -103,12 +103,19 @@ export class TabbedReportManager extends ImmutableMapLoader {
                 return dispatch(this.runNetworkAction('load', params, {
                     successHandler: (data) => {
                         let toUpdate = Immutable.Map()
+                        let finishedPages = Immutable.Set()
                         pages.forEach((reportId) => {
-                            let key = (baseKey)? baseKey.set('page', reportId) : reportId
-                            toUpdate = toUpdate.set(key, data.pages[reportId])
+                            let pageData = data.pages[reportId]
+                            if (pageData !== undefined) {
+                                let key = (baseKey)? baseKey.set('page', reportId) : reportId
+                                toUpdate = toUpdate.set(key, pageData)
+                                finishedPages = finishedPages.add(reportId)
+                            }
                         })
-                        dispatch(this.replaceItems(toUpdate))
-                        dispatch({type: this.finish_action, payload: pages})
+                        if (toUpdate.size) {
+                            dispatch(this.replaceItems(toUpdate))
+                            dispatch({type: this.finish_action, payload: finishedPages})
+                        }
                         setTimeout(flow, 200)
                     }
                 }))


### PR DESCRIPTION
This allows better responsiveness to tab changes et al.