### PR TITLE
Fix: Team Members who can have multiple accountabilities on submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,22 @@ language: php
 php:
   - 7.0
 
+env:
+  matrix:
+    - PHP_COVERAGE_ON=
+    - PHP_COVERAGE_ON=y
+
+matrix:
+  allow_failures:
+    - php: 7.0
+      env: PHP_COVERAGE_ON=y
+
 sudo: required
 
 cache:
   directories:
-    - src/vendor
     - src/node_modules
+    - src/vendor
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -26,9 +36,13 @@ before_script:
 script:
   - mkdir -p build/logs
   - >
+    if [[ $PHP_COVERAGE_ON = "y" ]]; then
+      export PHP_COVERAGE_OPTS="--coverage-clover build/logs/clover.xml";
+    fi
+  - >
     if [[ $TRAVIS_PHP_VERSION =~ ^7 ]]; then
       npm test -- --coverage &&
-      phpdbg -qrr vendor/bin/phpunit --coverage-clover build/logs/clover.xml;
+      phpdbg -qrr vendor/bin/phpunit $PHP_COVERAGE_OPTS -d memory_limit="1G";
     else
       php -d max_execution_time="1800" -d memory_limit="1G" vendor/bin/phpunit;
     fi
@@ -37,5 +51,10 @@ after_script:
   - ls -l build/logs/
   - >
     if [[ $TRAVIS_PHP_VERSION =~ ^7 ]]; then
-      travis_retry php vendor/bin/coveralls -v
+      if [[ $PHP_COVERAGE_ON = "y" ]]; then
+        travis_retry php vendor/bin/coveralls -v;
+      else
+        npm install coveralls &&
+        cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js;
+      fi
     fi

--- a/src/app/Accountability.php
+++ b/src/app/Accountability.php
@@ -1,6 +1,8 @@
 <?php
 namespace TmlpStats;
 
+use Carbon\Carbon;
+use DB;
 use Eloquence\Database\Traits\CamelCaseModel;
 use Illuminate\Database\Eloquent\Model;
 use TmlpStats\Traits\CachedRelationships;
@@ -32,5 +34,53 @@ class Accountability extends Model
         return $this->belongsToMany('TmlpStats\Person', 'accountability_person', 'accountability_id', 'person_id')
                     ->withPivot(['starts_at', 'ends_at'])
                     ->withTimestamps();
+    }
+
+    /**
+     * Remove anyone who is accountable for a given accountability in a given center.
+     *
+     * If the 'except' parameter is given, do not remove accountability from the given person ID.
+     *
+     * @param  int $accountabilityId Which accountability to remove.
+     * @param  int $centerId         Which center to use.
+     * @param  Carbon $asOf          The effective date of the removal.
+     * @param  int $except           If provided, do not remove this given person ID
+     */
+    public static function removeAccountabilityFromCenter($accountabilityId, $centerId, Carbon $asOf, $except = null)
+    {
+        // NOTE: this used to be an UPDATE... INNER JOIN which used to be able to do this change
+        // in only one query instead of potentially 1+N queries, but this was not a query
+        // which sqlite could handle, so it's been refactored to two queries.
+
+        // Phase 1: select unique persons with accountability in center.
+        $query = '
+            SELECT person_id, accountability_id
+            FROM accountability_person AS ap
+            INNER JOIN people AS p ON p.id = ap.person_id
+            WHERE
+                ap.accountability_id = ?
+                AND p.center_id = ?
+                AND (ap.ends_at IS NULL OR ap.ends_at > ?)';
+        $params = [$accountabilityId, $centerId, $asOf];
+
+        if ($except !== null) {
+            $query .= '   AND ap.person_id != ?';
+            $params[] = $except;
+        }
+
+        $results = DB::select($query, $params);
+
+        // Phase 2: Actually end these accountabilities.
+        foreach ($results as $entry) {
+            DB::update('
+                UPDATE accountability_person SET ends_at = ?, updated_at = ?
+                WHERE accountability_id = ?
+                      AND person_id = ?
+                      AND (ends_at IS NULL OR ends_at > ?)',
+                [$asOf, Carbon::now(), $accountabilityId, $entry->person_id, $asOf]);
+
+        }
+
+        return count($results);
     }
 }

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -39,7 +39,7 @@ class TeamMember extends AuthenticatedApiBase
             $options = [
                 'ignore' => ($includeData) ? false : self::$omitGitwTdo,
                 // setting time explicitly here to make sure we display accountabiles up to the time this report is active
-                'accountabilitiesFor' => $reportingDate->copy()->setTime(15,0,0),
+                'accountabilitiesFor' => $reportingDate->copy()->setTime(15, 0, 0),
             ];
             foreach (App::make(LocalReport::class)->getClassList($lastReport) as $tmd) {
                 // it's a small optimization, but prevent creating domain if we have an existing SubmissionData version
@@ -51,6 +51,7 @@ class TeamMember extends AuthenticatedApiBase
                     $domain = $allTeamMembers[$tmd->teamMemberId];
 
                 }
+                $domain->meta['personId'] = $tmd->teamMember->personId;
                 $domain->meta['hasThisWeekReportData'] = ($includeData);
             }
 

--- a/src/app/Domain/TeamMember.php
+++ b/src/app/Domain/TeamMember.php
@@ -205,4 +205,29 @@ class TeamMember extends ParserDomain
         return $output;
     }
 
+    /**
+     * Fetch the person associated with this TeamMember object.
+     *
+     * Will throw an exception if the person could not be found.
+     *
+     * @return Models\Person The person associated with this TeamMember domain.
+     */
+    public function getAssociatedPerson()
+    {
+        if (($personId = array_get($this->meta, 'personId', null)) !== null) {
+            $person = Models\Person::find($personId);
+            if ($person === null) {
+                throw new \Exception("Unexpected: Could not find person with ID {$personId}");
+            }
+        } else {
+            $teamMember = Models\TeamMember::find($this->id);
+            if ($teamMember === null) {
+                throw new \Exception("Unexpected: could not find team member with ID {$tm->id}");
+            }
+            $person = $teamMember->person;
+        }
+
+        return $person;
+    }
+
 }

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -57,6 +57,13 @@ $factory->define(TmlpStats\TeamMember::class, function (Faker\Generator $faker) 
     ];
 });
 
+$factory->defineAs(TmlpStats\TeamMember::class, 'noPerson', function(Faker\Generator $faker) {
+    return [
+        'team_year'           => $faker->numberBetween(1,2),
+        'incoming_quarter_id' => 1,
+    ];
+});
+
 $factory->define(TmlpStats\Course::class, function (Faker\Generator $faker) {
     return [
         'center_id'  => $faker->numberBetween(1, 24),

--- a/src/tests/functional/Api/SubmissionCoreTest.php
+++ b/src/tests/functional/Api/SubmissionCoreTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use TmlpStats as Models;
 use TmlpStats\Api;
+use TmlpStats\Domain;
 use TmlpStats\Tests\Functional\FunctionalTestAbstract;
 use TmlpStats\Tests\Mocks\MockContext;
 
@@ -31,7 +32,9 @@ class SubmissionCoreTest extends FunctionalTestAbstract
         $this->center = Models\Center::find($this->centerId);
         $this->quarter = Models\Quarter::year(2016)->quarterNumber(1)->first();
 
+        // Order important: context should be installed before creating a CenterQuarter which relies on context
         $this->context = MockContext::defaults()->withCenter($this->center)->install();
+        $this->cq = Domain\CenterQuarter::ensure($this->center, $this->quarter);
 
         $this->api = App::make(Api\SubmissionCore::class);
     }
@@ -104,5 +107,112 @@ class SubmissionCoreTest extends FunctionalTestAbstract
                 ],
             ],
         ];
+    }
+
+    /**
+     * @dataProvider providerSubmitTeamAccountabilities
+     */
+    public function testSubmitTeamAccountabilities($setAccountabilities)
+    {
+        $allAccountabilities = Models\Accountability::get()->keyBy('name');
+        $teamMembers = [];
+        $byName = [];
+        $findAcc = function ($accName) use ($allAccountabilities) {
+            return $allAccountabilities[$accName];
+        };
+
+        $reportNow = $this->reportingDate->copy()->setTime(15, 0, 0);
+        $quarterEndDate = $this->cq->endWeekendDate->copy()->addDay()->setTime(12, 00, 00);
+
+        // Create fake TMData
+        foreach ($this->sequentialNamedTeam() as $tm) {
+            $tmd = new Models\TeamMemberData(['at_weekend' => true]); // bogus
+            $domain = Domain\TeamMember::fromModel($tmd, $tm);
+            $domain->meta['personId'] = $tm->person->id;
+            $domain->meta['personObj'] = $tm->person; // atypical, only used for this test.
+            $teamMembers[$domain->id] = $domain;
+            $byName[$tm->firstName] = $domain->id;
+        }
+
+        // Set accountabilities from input, and set up 'initial' accountabilities as desired.
+        foreach ($setAccountabilities as $firstName => $data) {
+            $tmDomain = $teamMembers[$byName[$firstName]];
+            $setAccountabilities[$firstName]['initial'] = $initial = collect(array_get($data, 'initial', []))->map($findAcc);
+            foreach ($initial as $acc) {
+                $tmDomain->meta['personObj']->addAccountability($acc, $this->cq->firstWeekDate, $quarterEndDate);
+            }
+
+            if ($assigned = array_get($data, 'assign', null)) {
+                $tmDomain->accountabilities = collect($assigned)
+                    ->map($findAcc)
+                    ->pluck('id')
+                    ->sort()
+                    ->all();
+            }
+        }
+
+        // Actually run API
+        $this->api->submitTeamAccountabilities($this->center, $this->reportingDate, $reportNow, $quarterEndDate, $teamMembers);
+
+        $tomorrow = $this->reportingDate->copy()->addDay();
+        $yesterday = $this->reportingDate->copy()->subDay();
+        // Verify accountabilities were set effectively
+        foreach ($setAccountabilities as $firstName => $data) {
+            $tmDomain = $teamMembers[$byName[$firstName]];
+            $person = $tmDomain->meta['personObj'];
+            $current = $person->getAccountabilityIds($tomorrow);
+            sort($current);
+            $this->assertEquals($tmDomain->accountabilities, $current);
+            // Ensure 'initial' accountabilities were ended or continued.
+            foreach ($data['initial'] as $acc) {
+                $this->assertEquals(true, $person->hasAccountability($acc, $yesterday), "Expected {$firstName} to have accountability {$acc->name} yesterday");
+                if (in_array($acc->id, $tmDomain->accountabilities)) {
+                    $this->assertEquals(true, $person->hasAccountability($acc, $tomorrow));
+                } else {
+                    $this->assertEquals(false, $person->hasAccountability($acc, $tomorrow));
+                }
+            }
+        }
+    }
+
+    public function providerSubmitTeamAccountabilities()
+    {
+        return [
+            // set some accountabilities only with no initial values to fall bakc on
+            [[
+                'person1' => ['assign' => ['t1tl', 'cap']],
+                'person2' => ['assign' => ['t2tl']],
+                'person3' => ['assign' => ['cpc', 't1x']],
+            ]],
+
+            // second run: set with some existing initial values.
+            [[
+                'person1' => ['assign' => ['t1tl', 'cap']],
+                'person2' => ['assign' => ['t2tl']],
+                'person3' => ['assign' => ['cpc', 't1x']],
+                'person4' => [
+                    'initial' => ['cap', 'logistics'],
+                    'assign' => ['logistics'],
+                ],
+                'person5' => [
+                    'initial' => ['gitw'],
+                    'assign' => ['gitw', 'lf'],
+                ],
+            ]],
+
+        ];
+    }
+
+    public function sequentialNamedTeam()
+    {
+        $peeps = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $person = factory(Models\Person::class)->create(['first_name' => "person{$i}"]);
+            $teamMember = factory(Models\TeamMember::class, 'noPerson')->create(['person_id' => $person->id]);
+            $teamMember->setRelation('person', $person);
+            $peeps[] = $teamMember;
+        }
+
+        return $peeps;
     }
 }

--- a/src/tests/functional/Models/AccountabilityTest.php
+++ b/src/tests/functional/Models/AccountabilityTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace TmlpStats\Tests\Functional\Models;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use TmlpStats as Models;
+use TmlpStats\Tests\Functional\FunctionalTestAbstract;
+
+class AccountabilityTest extends FunctionalTestAbstract
+{
+    use DatabaseTransactions;
+    use WithoutMiddleware;
+    protected $instantiateApp = true;
+    protected $runMigrations = true;
+    protected $runSeeds = true;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->center = Models\Center::abbreviation('VAN')->first();
+    }
+
+    public function testRemoveAccountabilityFromCenter_except()
+    {
+        list($acc, $person, $person2) = $this->twoPeopleWithAccountabilities();
+        $this->assertEquals(1, count($person->getAccountabilityIds(Carbon::parse('2017-02-01'))));
+
+        // Remove the accountability excluding one person.
+        $changed = Models\Accountability::removeAccountabilityFromCenter($acc->id, $this->center->id, Carbon::parse('2017-01-30'), $person->id);
+        $this->assertEquals(1, $changed);
+        $this->assertEquals(1, count($person->getAccountabilityIds(Carbon::parse('2017-02-01')))); // Accountability still exists for this person.
+        $this->assertEquals(0, count($person2->getAccountabilityIds(Carbon::parse('2017-02-01')))); // but not for person 2
+        $this->assertEquals(1, count($person2->getAccountabilityIds(Carbon::parse('2017-01-29')))); // but still exists as of 01-29
+    }
+
+    public function testRemoveAccountabilityFromCenter_noExcept()
+    {
+        list($acc, $person, $person2) = $this->twoPeopleWithAccountabilities();
+
+        // Remove the accountability.
+        $changed = Models\Accountability::removeAccountabilityFromCenter($acc->id, $this->center->id, Carbon::parse('2017-01-30'));
+        $this->assertEquals(2, $changed);
+        $this->assertEquals(0, count($person->getAccountabilityIds(Carbon::parse('2017-02-01')))); // Removed.
+        $this->assertEquals(1, count($person->getAccountabilityIds(Carbon::parse('2017-01-29')))); // but still exists as of 01-29
+        $this->assertEquals(0, count($person2->getAccountabilityIds(Carbon::parse('2017-02-01')))); // Same for person 2.
+        $this->assertEquals(1, count($person2->getAccountabilityIds(Carbon::parse('2017-01-29')))); // but still exists as of 01-29
+    }
+
+    // factory helper - two people with the same accountability. Shouldn't happen often, but we're testing all edge cases here.
+    public function twoPeopleWithAccountabilities()
+    {
+        $acc = Models\Accountability::name('statistician')->first();
+        $person = factory(Models\Person::class)->create(['center_id' => $this->center->id]);
+        $person2 = factory(Models\Person::class)->create(['center_id' => $this->center->id]);
+
+        $person->addAccountability($acc, Carbon::parse('2017-01-01'), Carbon::parse('2017-06-01'));
+        $person2->addAccountability($acc, Carbon::parse('2017-01-01'), Carbon::parse('2017-07-01'));
+
+        return [$acc, $person, $person2];
+    }
+}


### PR DESCRIPTION
We were only keeping the first accountability after submission, losing
track of the others. This fixes that and refactors that code to PHP
for readability.