### PR TITLE
WIP - New approach for caching api report data

### DIFF
--- a/src/app/Api/Traits/CachesOutput.php
+++ b/src/app/Api/Traits/CachesOutput.php
@@ -1,0 +1,49 @@
+<?php
+namespace TmlpStats\Api\Traits;
+
+use Illuminate\Support\Facades\Storage;
+use TmlpStats as Models;
+
+trait CachesOutput
+{
+    protected function getCacheDir(Models\GlobalReport $report, Models\Region $region, $endpoint)
+    {
+        $class = ucfirst(class_basename($this));
+        return "cache/{$report->reportingDate->toDateString()}/{$class}/{$region->abbreviation}/{$endpoint}.json";
+    }
+
+    public function clearCache(Models\GlobalReport $report, Models\Region $region)
+    {
+        // clear cache
+        $class = ucfirst(class_basename($this));
+        Cache::tags(["{$class}{$report->id}"])->flush();
+
+        // rm saved report files
+        $dir = $this->getCacheDir($report, $region);
+        foreach(glob("{$dir}/*") as $file) {
+            if(is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    protected function getFromCache(Models\GlobalReport $report, Models\Region $region, $endpoint)
+    {
+        $cacheKey = $this->getCacheDir($report, $region, $endpoint);
+        if (!Storage::exists($cacheKey)) {
+            return null;
+        }
+
+        if ($contents = Storage::get($cacheKey)) {
+            return json_decode($contents, true);
+        }
+
+        return null;
+    }
+
+    protected function putInCache(Models\GlobalReport $report, Models\Region $region, $endpoint, $data)
+    {
+        $cacheKey = $this->getCacheDir($report, $region, $endpoint);
+        Storage::put($cacheKey, json_encode($data));
+    }
+}

--- a/src/app/GlobalReport.php
+++ b/src/app/GlobalReport.php
@@ -1,12 +1,13 @@
 <?php
 namespace TmlpStats;
 
+use App;
+use Cache;
+use Carbon\Carbon;
 use Eloquence\Database\Traits\CamelCaseModel;
 use Illuminate\Database\Eloquent\Model;
+use TmlpStats\Api;
 use TmlpStats\Traits\CachedRelationships;
-
-use Carbon\Carbon;
-use Cache;
 
 class GlobalReport extends Model
 {
@@ -36,6 +37,7 @@ class GlobalReport extends Model
         $this->statsReports()->attach($report->id);
 
         Cache::tags(["globalReport{$this->id}"])->flush();
+        App::make(Api\GlobalReport::class)->clearCache();
     }
 
     public function getStatsReportByCenter(Center $center)

--- a/src/app/Http/Controllers/Encapsulate/GlobalReportRegionGamesData.php
+++ b/src/app/Http/Controllers/Encapsulate/GlobalReportRegionGamesData.php
@@ -2,7 +2,6 @@
 namespace TmlpStats\Http\Controllers\Encapsulate;
 
 use App;
-use Carbon\Carbon;
 use TmlpStats as Models;
 use TmlpStats\Api;
 use TmlpStats\Encapsulations;
@@ -17,27 +16,7 @@ class GlobalReportRegionGamesData
     {
         $this->globalReport = $globalReport;
         $this->region = $region;
-        $this->data = $this->getGamesData($globalReport->reportingDate, $region);
-    }
-
-    protected function getGamesData(Carbon $reportingDate, Models\Region $region)
-    {
-        $regionQuarter = App::make(Api\Context::class)->getEncapsulation(Encapsulations\RegionQuarter::class, [
-            'quarter' => Models\Quarter::getQuarterByDate($reportingDate, $region),
-            'region' => $region,
-        ]);
-
-        $reports = Models\GlobalReport::between($regionQuarter->startWeekendDate, $regionQuarter->endWeekendDate)->get();
-
-        $weeksData = [];
-        foreach ($reports as $weekReport) {
-            $dateStr = $weekReport->reportingDate->toDateString();
-            $week = App::make(Api\GlobalReport::class)->getWeekScoreboardByCenter($weekReport, $region);
-            ksort($week);
-            $weeksData[$dateStr] = $week;
-        }
-
-        return $weeksData;
+        $this->data = App::make(Api\GlobalReport::class)->getGamesDataAllWeeks($globalReport, $region);
     }
 
     protected function filterGame($game, array $reports, Models\Region $region)

--- a/src/app/Reports/Arrangements/RegionByRating.php
+++ b/src/app/Reports/Arrangements/RegionByRating.php
@@ -1,5 +1,8 @@
-<?php namespace TmlpStats\Reports\Arrangements;
+<?php
+namespace TmlpStats\Reports\Arrangements;
 
+use App;
+use TmlpStats\Http\Controllers\StatsReportController;
 use TmlpStats\StatsReport;
 
 class RegionByRating extends BaseArrangement
@@ -25,7 +28,11 @@ class RegionByRating extends BaseArrangement
         $centerReports = array();
         foreach ($centerPoints as $points => $reports) {
             foreach ($reports as $report) {
-                $centerReports[$report->getRating()][] = $report;
+                $centerReports[$report->getRating()][] = [
+                    'points' => (int) $report->getPoints(),
+                    'center' => $report->center->name,
+                    'link' => App::make(StatsReportController::class)->getUrl($report),
+                ];
             }
         }
 

--- a/src/resources/views/globalreports/details/ratingsummary.blade.php
+++ b/src/resources/views/globalreports/details/ratingsummary.blade.php
@@ -47,27 +47,27 @@ $ratingColors = [
             <?php $count = 0; ?>
             @foreach ($statsReports as $report)
                 <?php
-                    $meterClass = ($report->getPoints() > 0) ? 'meter' : 'meter-zero';
+                    $meterClass = ($report['points'] > 0) ? 'meter' : 'meter-zero';
 
                     // Width must always be > 0 to display even when 0 points
-                    $meterWidth = max(round(($report->getPoints()/28)*100), 4);
+                    $meterWidth = max(round(($report['points'] / 28) * 100), 4);
                 ?>
                 <tr class="points">
                     @if ($count === 0)
                         <?php $count++; ?>
                         <td class="data-point" rowspan="{{ count($rows[$rating]) }}">{{ $rating }}</td>
                     @endif
-                    <td class="data-point" style="background-color: {{ $ratingColors[(int) $report->getPoints()] }}; font-weight: bold;">
-                        @statsReportLink($report)
+                    <td class="data-point" style="background-color: {{ $ratingColors[$report['points']] }}; font-weight: bold;">
+                        <a href="{{ $report['link'] }}">
                             <div class="{{ $meterClass }}">
-                                <span style="width: {{ $meterWidth }}%">{{ (int) $report->getPoints() }}</span>
+                                <span style="width: {{ $meterWidth }}%">{{ $report['points'] }}</span>
                             </div>
-                        @endStatsReportLink
+                        </a>
                     </td>
                     <td>
-                        @statsReportLink($report)
-                            <div style="margin-left: 5px">{{ $report->center->name }}</div>
-                        @endStatsReportLink
+                        <a href="{{ $report['link'] }}">
+                            <div style="margin-left: 5px">{{ $report['center'] }}</div>
+                        </a>
                     </td>
                 </tr>
             @endforeach


### PR DESCRIPTION
This is a new concept for caching report data in a more persistent way than memcache. There is still some thinking needed around how cache busting will work and making the trait more generic.

Cached here are the Rating Summary page and the data used by the Game Effectiveness reports.