### PR TITLE
Fix regression in validating legacy (spreadsheet) reports

### DIFF
--- a/src/app/Validate/Objects/ContactInfoValidator.php
+++ b/src/app/Validate/Objects/ContactInfoValidator.php
@@ -2,8 +2,9 @@
 namespace TmlpStats\Validate\Objects;
 
 use App;
-use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
 use Respect\Validation\Validator as v;
+use TmlpStats\Api;
+use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
 
 class ContactInfoValidator extends ObjectsValidatorAbstract
 {


### PR DESCRIPTION
Was getting exception caused by missing namespace