### PR TITLE
Trim names and other things.

### DIFF
--- a/src/app/Api/Parsers/DictInput.php
+++ b/src/app/Api/Parsers/DictInput.php
@@ -34,7 +34,7 @@ class DictInput
                 }
             }
 
-            $parser = Factory::build($shape[$key]['type']);
+            $parser = Factory::build($shape[$key]['type'], array_get($conf, 'options', null));
             $output[$key] = $parser->run($data, $key, $required);
         }
 

--- a/src/app/Api/Parsers/Factory.php
+++ b/src/app/Api/Parsers/Factory.php
@@ -7,8 +7,9 @@ use TmlpStats\Api\Parsers;
 
 class Factory
 {
-    public static function build($type)
+    public static function build($type, $options = [])
     {
+        $input = ['options' => $options];
         switch ($type) {
             case 'array':
                 return App::make(Parsers\ArrayParser::class);
@@ -19,7 +20,7 @@ class Factory
             case 'int':
                 return App::make(Parsers\IntParser::class);
             case 'string':
-                return App::make(Parsers\StringParser::class);
+                return App::make(Parsers\StringParser::class, $input);
             case 'Application':
                 return App::make(Parsers\ApplicationParser::class);
             case 'Center':

--- a/src/app/Api/Parsers/ParserBase.php
+++ b/src/app/Api/Parsers/ParserBase.php
@@ -7,10 +7,16 @@ use TmlpStats\Util;
 abstract class ParserBase
 {
     protected $type = '';
+    protected $parserOptions;
 
     public static function create()
     {
         return new static();
+    }
+
+    public function __construct($options = [])
+    {
+        $this->parserOptions = $options;
     }
 
     public function run($input, $key, $required = true)

--- a/src/app/Api/Parsers/StringParser.php
+++ b/src/app/Api/Parsers/StringParser.php
@@ -12,6 +12,11 @@ class StringParser extends ParserBase
 
     public function parse($value)
     {
-        return (string) $value;
+        $value = (string) $value;
+        if (array_get($this->parserOptions, 'trim', false)) {
+            $value = trim($value);
+        }
+
+        return $value;
     }
 }

--- a/src/app/Domain/Course.php
+++ b/src/app/Domain/Course.php
@@ -28,6 +28,7 @@ class Course extends ParserDomain
         'location' => [
             'owner' => 'course',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'id' => [
             'owner' => 'course',

--- a/src/app/Domain/ProgramLeader.php
+++ b/src/app/Domain/ProgramLeader.php
@@ -18,18 +18,22 @@ class ProgramLeader extends ParserDomain
         'firstName' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'lastName' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'phone' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'email' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'center' => [
             'owner' => 'person',

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -14,14 +14,17 @@ class TeamApplication extends ParserDomain
         'firstName' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'lastName' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'email' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'center' => [
             'owner' => 'person',
@@ -90,6 +93,7 @@ class TeamApplication extends ParserDomain
         'phone' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         /*
         FIELDS WE CURRENTLY DO NOT CARE ABOUT

--- a/src/app/Domain/TeamMember.php
+++ b/src/app/Domain/TeamMember.php
@@ -18,10 +18,13 @@ class TeamMember extends ParserDomain
         'firstName' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
+
         ],
         'lastName' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'phone' => [
             'owner' => 'person',
@@ -30,6 +33,7 @@ class TeamMember extends ParserDomain
         'email' => [
             'owner' => 'person',
             'type' => 'string',
+            'options' => ['trim' => true],
         ],
         'center' => [
             'owner' => 'person',


### PR DESCRIPTION
A number of bugs have come up in reports, transfer check, and other
places where we rely on name matching, due to the fact that often due
to cut&paste, there's additional whitespace around a name.

Use the 'trim' option to trim first/last names and other things which
are likely to have whitespace cruft.