### PR TITLE
Add support to delete team member/application stashes.

### DIFF
--- a/docker/mysql/sql/040-views.sql
+++ b/docker/mysql/sql/040-views.sql
@@ -170,7 +170,8 @@ CREATE OR REPLACE VIEW `submission_data_team_members` AS
         `submission_data` left outer join `team_members`
               on `submission_data`.stored_id=`team_members`.id
     WHERE
-        (`submission_data`.`stored_type` = 'team_member');
+        (`submission_data`.`stored_type` = 'team_member' 
+          AND NOT JSON_CONTAINS_PATH(`submission_data`.`data`, 'one', '$.__deleted'));
 
 CREATE OR REPLACE VIEW submission_data_accountabilities AS
     SELECT

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -4,7 +4,7 @@ namespace TmlpStats\Api;
 use App;
 use Carbon\Carbon;
 use TmlpStats as Models;
-use TmlpStats\Api\Base\ApiBase;
+use TmlpStats\Api\Base\AuthenticatedApiBase;
 use TmlpStats\Api\Exceptions;
 use TmlpStats\Api\Traits;
 use TmlpStats\Domain;
@@ -12,7 +12,7 @@ use TmlpStats\Domain;
 /**
  * Applications
  */
-class Application extends ApiBase
+class Application extends AuthenticatedApiBase
 {
     use Traits\UsesReportDates, Traits\ValidatesObjects;
 

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -5,6 +5,7 @@ use App;
 use Carbon\Carbon;
 use TmlpStats as Models;
 use TmlpStats\Api\Base\ApiBase;
+use TmlpStats\Api\Exceptions;
 use TmlpStats\Api\Traits;
 use TmlpStats\Domain;
 
@@ -20,21 +21,28 @@ class Application extends ApiBase
         App::make(SubmissionCore::class)->checkCenterDate($center, $reportingDate);
 
         $allApplications = [];
+        $deleted = collect([]);
         if ($includeInProgress) {
             $submissionData = App::make(SubmissionData::class);
-            $found = $submissionData->allForType($center, $reportingDate, Domain\TeamApplication::class);
+            list($found, $deleted) = $submissionData->allForType($center, $reportingDate, Domain\TeamApplication::class, ['include_deleted' => true]);
             foreach ($found as $domain) {
                 $allApplications[$domain->id] = $domain;
                 $domain->meta['localChanges'] = true;
+                $domain->meta['canDelete'] = true;
             }
+
+            $deleted = $deleted->map(function ($x) {return intval($x);})->flip();
         }
 
         $lastReport = $this->relevantReport($center, $reportingDate);
         if ($lastReport) {
             $applications = App::make(LocalReport::class)->getApplicationsList($lastReport, ['returnUnprocessed' => true]);
             foreach ($applications as $appData) {
-                // it's a small optimization, but prevent creating domain if we have an existing SubmissionData version
-                if (isset($allApplications[$appData->tmlpRegistrationId])) {
+                if ($deleted->has($appData->tmlpRegistrationId)) {
+                    continue;
+                } else if ($domain = array_get($allApplications, $appData->tmlpRegistrationId)) {
+                    // it's a small optimization, but prevent creating domain if we have an existing SubmissionData version
+                    $domain->meta['canDelete'] = false;
                     continue;
                 }
 
@@ -56,6 +64,11 @@ class Application extends ApiBase
     public function stash(Models\Center $center, Carbon $reportingDate, array $data)
     {
         App::make(SubmissionCore::class)->checkCenterDate($center, $reportingDate, ['write']);
+        $this->assertCan('submitStats', $center);
+
+        if (array_get($data, 'action', '') == 'delete') {
+            return $this->deleteApp($center, $reportingDate, $data['id']);
+        }
 
         $submissionData = App::make(SubmissionData::class);
         $appId = $submissionData->numericStorageId($data, 'id');
@@ -71,6 +84,7 @@ class Application extends ApiBase
         } else {
             $teamApp = Domain\TeamApplication::fromArray($data);
         }
+
         $report = LocalReport::ensureStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $teamApp, $appId, $pastWeeks);
 
@@ -89,6 +103,22 @@ class Application extends ApiBase
             'storedId' => $appId,
             'valid' => $validationResults['valid'],
             'messages' => $validationResults['messages'],
+        ];
+    }
+
+    protected function deleteApp(Models\Center $center, Carbon $reportingDate, $appId)
+    {
+        $appId = intval($appId);
+        // Cannot override delete for an application with an actual ID
+        if ($appId > 0 && !$this->context->can('overrideDelete', $center)) {
+            throw new Exceptions\UnauthorizedException('Cannot delete this application without delete override privileges.');
+        }
+        App::make(SubmissionData::class)
+            ->deleteOne($center, $reportingDate, Domain\TeamApplication::class, $appId);
+
+        return [
+            'success' => true,
+            'valid' => true,
         ];
     }
 

--- a/src/app/Policies/CenterPolicy.php
+++ b/src/app/Policies/CenterPolicy.php
@@ -69,4 +69,9 @@ class CenterPolicy extends Policy
     {
         return $user->hasRole('globalStatistician');
     }
+
+    public function overrideDelete(User $user, Center $center)
+    {
+        return $user->hasRole('globalStatistician');
+    }
 }

--- a/src/app/SubmissionData.php
+++ b/src/app/SubmissionData.php
@@ -17,45 +17,12 @@ class SubmissionData extends Model
     ];
 
     /**
-     * Return the data coerced to the type defined by typeMapping.
-     * The class in question has to have a static method fromArray
-     * @return Data in the type defined by typeMapping
+     * Returns true if this has been soft deleted
+     * @return boolean [description]
      */
-    public function getTypedData()
+    public function isSoftDeleted(): bool
     {
-        $className = static::$typeMapping[$this->storedType]['class'];
-
-        return $className::fromArray($this->data);
-    }
-
-    public function setTypedData($data)
-    {
-        $info = static::mappingForObj($data);
-        if ($info === null) {
-            // if we reach here, then we didn't find a type mapping
-            throw new \Exception("Unknown type mapping {$className}");
-        }
-
-        $this->storedType = $info['storedType'];
-        $this->storedId = $info['storedId'];
-        $this->data = $data->toArray();
-    }
-
-    protected static function mappingForObj($data)
-    {
-        $className = get_class($data);
-        foreach (static::$typeMapping as $k => $v) {
-            if ($v['class'] == $className) {
-                $idAttr = $v['idAttr'];
-
-                return [
-                    'storedType' => $k,
-                    'storedId' => $data->$idAttr,
-                ];
-            }
-        }
-
-        return null;
+        return array_get($this->data, '__deleted', false);
     }
 
     public function scopeCenter($query, $center)

--- a/src/config/tmlp.php
+++ b/src/config/tmlp.php
@@ -8,4 +8,6 @@ return [
 
     'global_report_view_mode' => env('GLOBAL_REPORT_VIEW_MODE', 'react'),
     'local_report_view_mode' => env('LOCAL_REPORT_VIEW_MODE', 'html'),
+
+    'earliest_submission' => '2017-06-02',
 ];

--- a/src/resources/assets/js/reusable/form_utils/index.jsx
+++ b/src/resources/assets/js/reusable/form_utils/index.jsx
@@ -27,15 +27,16 @@ export class SimpleField extends React.Component {
         required: false
     }
     render() {
+        const computedId = 'fl-' + this.props.model.replace(/\./, '_')
         var field
         if (this.props.customField) {
-            field = <Field model={this.props.model}>{this.props.children}</Field>
+            field = <Field model={this.props.model} aria-labelledby={computedId}>{this.props.children}</Field>
         } else {
             let controlProps = this.props.controlProps || {}
             if (this.props.disabled) {
                 controlProps = objectAssign({}, controlProps, {disabled: this.props.disabled})
             }
-            field = <NullableTextControl model={this.props.model} controlProps={controlProps} />
+            field = <NullableTextControl model={this.props.model} controlProps={controlProps} aria-labelledby={computedId} />
         }
 
         const { labelClass, divClass, required } = this.props
@@ -48,7 +49,7 @@ export class SimpleField extends React.Component {
         return (
             <Field model={this.props.model}>
                 <div className={requiredClass + ' form-group'}>
-                    <label className={labelClass + ' control-label'}>{this.props.label}</label>
+                    <label className={labelClass + ' control-label'} id={computedId}>{this.props.label}</label>
                     <div className={divClass}>{field}</div>
                 </div>
             </Field>
@@ -64,21 +65,25 @@ export class SimpleFormGroup extends React.PureComponent {
     }
     static propTypes = {
         labelClass: PropTypes.string.isRequired,
+        labelFor: PropTypes.string,
         divClass: PropTypes.string,
         label: PropTypes.any.isRequired,
-        required: PropTypes.bool
+        required: PropTypes.bool,
+        children: PropTypes.node
     }
     render() {
-        const { label, labelClass, divClass, required } = this.props
+        const { label, labelClass, divClass, required, labelFor, children } = this.props
 
-        let requiredClass = ''
-        if (required) {
-            requiredClass = 'required'
+        const requiredClass = required? 'required' : ''
+        let labelProps = {className: `${labelClass} control-label`}
+        if (labelFor) {
+            labelProps.htmlFor = labelFor
         }
+
         return (
             <div className={requiredClass + ' form-group'}>
-                <label className={labelClass + ' control-label'}>{label}</label>
-                <div className={divClass}>{this.props.children}</div>
+                <label {...labelProps}>{label}</label>
+                <div className={divClass}>{children}</div>
             </div>
         )
     }
@@ -108,6 +113,7 @@ export class Select extends React.PureComponent {
     }
     static propTypes = {
         model: PropTypes.string,
+        id: PropTypes.string,
         items: PropTypes.arrayOf(PropTypes.object).isRequired,
         keyProp: PropTypes.string,
         getKey: PropTypes.func,
@@ -147,7 +153,7 @@ export class Select extends React.PureComponent {
         return (
             <Control.select
                     model={this.props.model} multiple={this.props.multiple} changeAction={this.props.changeAction}
-                    className={requiredClass + ' form-control'} rows={this.props.rows}>
+                    className={requiredClass + ' form-control'} rows={this.props.rows} id={this.props.id}>
                 {options}
             </Control.select>
         )

--- a/src/resources/assets/js/reusable/redux_loader/simple.js
+++ b/src/resources/assets/js/reusable/redux_loader/simple.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import { objectAssign } from '../ponyfill'
 import { ReduxLoader } from './base'
 
@@ -6,6 +8,7 @@ export default class SimpleReduxLoader extends ReduxLoader {
         super(opts)
         this.replace_action = opts.prefix + '/replace'
         this.replace_items_action = opts.prefix + '/replace_items'
+        this.delete_item_action = opts.prefix + '/delete'
     }
 
     dataReducer(opts) {
@@ -16,6 +19,8 @@ export default class SimpleReduxLoader extends ReduxLoader {
                 return action.payload
             case this.replace_items_action:
                 return objectAssign({}, state, action.payload)
+            case this.delete_item_action:
+                return _.omit(state, [action.payload])
             }
             return state
         }
@@ -31,5 +36,9 @@ export default class SimpleReduxLoader extends ReduxLoader {
 
     replaceItems(values) {
         return {type: this.replace_items_action, payload: values}
+    }
+
+    deleteItem(key) {
+        return {type: this.delete_item_action, payload: key}
     }
 }

--- a/src/resources/assets/js/reusable/sort-helpers.js
+++ b/src/resources/assets/js/reusable/sort-helpers.js
@@ -64,11 +64,11 @@ function createIteratee(key) {
 }
 
 export function createSorters(input) {
-    let m = Immutable.Map()
-    input.forEach((v) => {
-        m = m.set(v.key, v)
+    return Immutable.OrderedMap().withMutations((m) => {
+        input.forEach((v) => {
+            m.set(v.key, v)
+        })
     })
-    return  m
 }
 
 const defaultInputSelectors = [

--- a/src/resources/assets/js/submission/applications/actions.js
+++ b/src/resources/assets/js/submission/applications/actions.js
@@ -61,23 +61,28 @@ export function saveApplication(center, reportingDate, data) {
             center, reportingDate, data
         }).then((result) => {
             dispatch(markStale())
-            // Failed during validation
-            if (!result.storedId) {
-                dispatch(messages.replace('create', result.messages))
-                reset()
+
+            if (data.action == 'delete') {
+                setTimeout(() => dispatch(loadState('new')), 100) // Force server re-fetch
                 return result
             }
 
-            let newData = objectAssign({}, data, {id: result.storedId})
-            dispatch(appsCollection.replaceItem(newData.id, newData))
-            dispatch(messages.replace(result.storedId, result.messages))
+            // Failed during validation
+            if (!result.storedId) {
+                dispatch(messages.replace('create', result.messages))
+            } else {
+                let newData = objectAssign({}, data, {id: result.storedId})
+                dispatch(appsCollection.replaceItem(newData.id, newData))
+                dispatch(messages.replace(result.storedId, result.messages))
 
-            // We successfully saved, reset any existing parser messages
-            if (!data.id) {
-                dispatch(messages.replace('create', []))
+                // We successfully saved, reset any existing parser messages
+                if (!data.id) {
+                    dispatch(messages.replace('create', []))
+                }
             }
+
             reset()
-            return result // Because it's a Promise is you have to return results to continue the chain.
+            return result // Because it's a Promise, you have to return results to continue the chain.
         }).catch((err) => {
             // If this is a parser error, we won't have an ID yet, use 'create'
             const id = data.id ? data.id : 'create'
@@ -87,8 +92,4 @@ export function saveApplication(center, reportingDate, data) {
             scrollIntoView('react-routed-flow')
         })
     }
-}
-
-export function setAppStatus(status) {
-    return formActions.change('submission.applications.currentApp.appStatus', status)
 }

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -361,8 +361,7 @@ class _EditCreate extends ApplicationsBase {
                 <div>
                     <p><b>Regional Statisticians</b> - This application cannot be deleted by a statistician.
                     You can override the delete, but please be advised that this
-                    will <b>retroactively</b> change reports, including maybe for
-                    last week.</p>
+                    will change reports, and potentially make things not add up.</p>
 
                     <p>If you wish to continue, please enter the full name '{extraConfirm}' below.</p>
                 </div>

--- a/src/resources/assets/js/submission/applications/components.jsx
+++ b/src/resources/assets/js/submission/applications/components.jsx
@@ -1,7 +1,7 @@
 import { Link, withRouter } from 'react-router'
 import { defaultMemoize } from 'reselect'
 
-import { Control, Form, SimpleField, SimpleSelect, SimpleFormGroup, BooleanSelect, AddOneLink, formActions } from '../../reusable/form_utils'
+import { Control, Form, SimpleField, Select, SimpleFormGroup, BooleanSelect, AddOneLink, formActions } from '../../reusable/form_utils'
 import { objectAssign } from '../../reusable/ponyfill'
 import { rebind, delayDispatch, connectRedux } from '../../reusable/dispatch'
 import { SORT_BY } from '../../reusable/sort-helpers'
@@ -13,6 +13,7 @@ import { SubmissionBase, React } from '../base_components'
 import { APPLICATIONS_FORM_KEY } from './reducers'
 import { appsSorts, appsCollection } from './data'
 import { centerQuarterData } from '../core/data'
+import DeleteWarning from '../core/DeleteWarning'
 import { loadApplications, saveApplication, chooseApplication } from './actions'
 import AppStatus from './AppStatus'
 
@@ -77,7 +78,7 @@ export class ApplicationsIndex extends ApplicationsBase {
 
             withdraws.push(
                 <tr key={key}>
-                    <td><Link to={`${baseUri}/edit/${key}`}>{app.firstName} {app.lastName}</Link></td>
+                    <td><Link to={`${baseUri}/edit/${key}`}>{nameRow(app)}</Link></td>
                     <td>{app.teamYear}</td>
                     <td>{quarterLabel}</td>
                     <td>{app.regDate}</td>
@@ -132,7 +133,7 @@ export class ApplicationsIndex extends ApplicationsBase {
 
             apps.push(
                 <tr key={key}>
-                    <td><Link to={`${baseUri}/edit/${key}`}>{app.firstName} {app.lastName}</Link></td>
+                    <td><Link to={`${baseUri}/edit/${key}`}>{nameRow(app)}</Link></td>
                     <td>{app.teamYear}</td>
                     <td>{quarterLabel}</td>
                     <td>{app.regDate}</td>
@@ -186,6 +187,7 @@ class _EditCreate extends ApplicationsBase {
             const tmp = teamMembersData.opts.getSortedMembers(teamMembers)
             return tmp.filter(tm => tm.id && parseInt(tm.id) > 0)
         })
+        rebind(this, 'saveAppData', 'deleteApp')
     }
     checkLoading() {
         if (!super.checkLoading()) {
@@ -228,8 +230,8 @@ class _EditCreate extends ApplicationsBase {
                     {this.renderStartingQuarter(modelKey)}
                     <SimpleField label="First Name" model={modelKey+'.firstName'} divClass="col-md-6" required={true} />
                     <SimpleField label="Last Initial" model={modelKey+'.lastName'} divClass="col-md-6" required={true} />
-                    <SimpleFormGroup label="Team Year" divClass="col-md-4" required={true}>
-                        <Control.select model={modelKey+'.teamYear'} className="form-control" style={{maxWidth: '10em'}}>
+                    <SimpleFormGroup label="Team Year" divClass="col-md-4" required={true} labelFor="f-app-teamYear">
+                        <Control.select model={modelKey+'.teamYear'} className="form-control" style={{maxWidth: '10em'}} id="f-app-teamYear">
                             <option value="1">Team 1</option>
                             <option value="2">Team 2</option>
                         </Control.select>
@@ -237,14 +239,12 @@ class _EditCreate extends ApplicationsBase {
                     <SimpleField label="Comment" model={modelKey+'.comment'} divClass="col-md-6" customField={true}>
                         <textarea className="form-control" rows="3"></textarea>
                     </SimpleField>
-                    <div className="required form-group">
-                        <label className="col-md-2 control-label">Committed Team Member</label>
-                        <div className="col-md-6">
-                            <SimpleSelect
-                                    model={modelKey+'.committedTeamMember'} items={selectableMembers}
-                                    keyProp="id" getLabel={teamMembersData.opts.getLabel} emptyChoice="Choose One" />
-                        </div>
-                    </div>
+                    <SimpleFormGroup label="Committed Team Member" required={true} labelFor="f-app-commitedTeamMember" divClass="col-md-6">
+                        <Select
+                                id="f-app-committedTeamMember"
+                                model={modelKey+'.committedTeamMember'} items={selectableMembers}
+                                keyProp="id" getLabel={teamMembersData.opts.getLabel} emptyChoice="Choose One" />
+                    </SimpleFormGroup>
                     <div className="form-group">
                         <label className="col-md-2 control-label">Application Status</label>
                         <div className="col-md-9">
@@ -254,6 +254,7 @@ class _EditCreate extends ApplicationsBase {
                     {this.renderTravelRoom(modelKey)}
                     <ButtonStateFlip loadState={this.props.saveApp} offset='col-sm-offset-2 col-sm-8' wrapGroup={true}>Save</ButtonStateFlip>
                 </Form>
+                {this.renderDeleteFlow(modelKey)}
             </div>
         )
     }
@@ -271,7 +272,7 @@ class _EditCreate extends ApplicationsBase {
         const CHANGING_QUARTER_KEY = '_changingQuarter'
         const isNewApp = this.isNewApp()
         if (isNewApp || currentApp[CHANGING_QUARTER_KEY]) {
-            body = <SimpleSelect model={modelKey+'.incomingQuarter'} items={centerQuarters}
+            body = <Select model={modelKey+'.incomingQuarter'} items={centerQuarters}
                                  keyProp="quarterId" getLabel={centerQuarterData.getLabel} />
         } else {
             const clickHandler = () => {
@@ -329,7 +330,7 @@ class _EditCreate extends ApplicationsBase {
     // saveAppData for now is the same between edit and create flows
     saveAppData(data) {
         const { router, dispatch, params: {centerId, reportingDate} } = this.props
-        dispatch(saveApplication(centerId, reportingDate, data)).then((result) => {
+        return dispatch(saveApplication(centerId, reportingDate, data)).then((result) => {
             if (!result) {
                 return
             }
@@ -345,6 +346,43 @@ class _EditCreate extends ApplicationsBase {
                 router.push(this.appsBaseUri())
             }
         })
+    }
+
+    renderDeleteFlow(modelKey) {
+        const { currentApp, lookups } = this.props
+        let extraConfirm, spiel
+        if (!currentApp.id) {
+            return
+        } else if (currentApp.meta && currentApp.meta.canDelete) {
+            spiel = <p>Deleting an application will cause the application to be permanently removed.</p>
+        } else if (lookups.user.canOverrideDelete) {
+            extraConfirm = nameRow(currentApp)
+            spiel = (
+                <div>
+                    <p><b>Regional Statisticians</b> - This application cannot be deleted by a statistician.
+                    You can override the delete, but please be advised that this
+                    will <b>retroactively</b> change reports, including maybe for
+                    last week.</p>
+
+                    <p>If you wish to continue, please enter the full name '{extraConfirm}' below.</p>
+                </div>
+            )
+        } else {
+            return
+        }
+        return (
+            <div style={{maxWidth: '80em', marginTop: '3em'}}>
+                <DeleteWarning
+                        model={modelKey} noun="Application" spiel={spiel}
+                        extraConfirm={extraConfirm} onSubmit={this.deleteApp}
+                        buttonState={this.props.saveApp} />
+            </div>
+        )
+    }
+
+    deleteApp(data) {
+        data = objectAssign({}, data, {action: 'delete'})
+        this.saveAppData(data)
     }
 }
 
@@ -414,4 +452,11 @@ export class ApplicationsAdd extends _EditCreate {
         return super.render()
     }
 
+}
+
+function nameRow(app) {
+    if (!app.firstName && !app.lastName) {
+        return '<Name Blank>'
+    }
+    return (app.firstName || 'unknown') + ' ' + (app.lastName || 'unknown')
 }

--- a/src/resources/assets/js/submission/core/DeleteWarning.jsx
+++ b/src/resources/assets/js/submission/core/DeleteWarning.jsx
@@ -1,0 +1,79 @@
+import _ from 'lodash'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Form, Control, actions as formActions } from 'react-redux-form'
+
+import { loadStateShape } from '../../reusable/shapes'
+import { Panel, ButtonStateFlip } from '../../reusable/ui_basic'
+import { rebind, connectRedux } from '../../reusable/dispatch'
+
+const extraConfirmProp = '_extraConfirm'
+
+@connectRedux()
+export default class DeleteWarning extends Component {
+    static mapStateToProps(state, ownProps) {
+        const v = {}
+        if (ownProps.extraConfirm) {
+            v.extraConfirmValue = _.get(state, `${ownProps.model}.${extraConfirmProp}`)
+        }
+        return v
+    }
+    static propTypes = {
+        model: PropTypes.string.isRequired,
+        noun: PropTypes.string.isRequired,
+        buttonState: loadStateShape,
+        extraConfirm: PropTypes.string,
+        extraConfirmValue: PropTypes.string,
+        onSubmit: PropTypes.func,
+        spiel: PropTypes.node,
+    }
+
+    constructor(props) {
+        super(props)
+        rebind(this, 'preSubmit')
+    }
+
+    render() {
+
+        const { spiel, noun, model, buttonState, extraConfirm, extraConfirmValue } = this.props
+        let button, extra
+
+        const renderSpiel = (typeof spiel == 'string')? <p>{spiel}</p> : spiel
+
+        if (buttonState) {
+            button = <ButtonStateFlip buttonClass="btn btn-danger" loadState={buttonState}>Delete</ButtonStateFlip>
+        } else {
+            button = <button className="btn btn-danger" type="submit">Delete</button>
+        }
+
+        if (extraConfirm) {
+            extra = <Control.text model={`${model}.${extraConfirmProp}`} className="form-control" />
+            if (extraConfirmValue != extraConfirm) {
+                button = undefined
+            }
+        }
+
+        return (
+            <Panel heading={`Delete ${noun}`}>
+                <Form model={model} onSubmit={this.preSubmit}>
+                    {renderSpiel}
+                    {extra}
+                    {button}
+                </Form>
+            </Panel>
+        )
+    }
+
+    preSubmit(data) {
+        if (!confirm(`Are you SURE you want to delete this ${this.props.noun}?`)) {
+            return // stop action continuing
+        }
+        if (this.props.extraConfirm) {
+            // Probably not needed since we hide the button until the text is entered, but not a big deal to check
+            if (data[extraConfirmProp] != this.props.extraConfirm) {
+                return alert('Must match names')
+            }
+        }
+        this.props.onSubmit(data)
+    }
+}

--- a/src/resources/assets/js/submission/team_members/actions.js
+++ b/src/resources/assets/js/submission/team_members/actions.js
@@ -86,6 +86,11 @@ export function stashTeamMember(center, reportingDate, data) {
         successHandler(result, { dispatch }) {
             dispatch(markStale())
             // The request failed before creating an id (parser error)
+            if (data.action == 'delete') {
+                // Force reloading team members rather than deleting in our state machine.
+                setTimeout(() => dispatch(teamMembersData.loadState('new')), 50)
+                return
+            }
             if (!result.storedId) {
                 dispatch(teamMembersData.saveState({error: 'Validation Failed', messages: result.messages}))
                 setTimeout(() => { dispatch(teamMembersData.saveState('new')) }, 3000)

--- a/src/resources/assets/js/submission/team_members/components-add-edit.jsx
+++ b/src/resources/assets/js/submission/team_members/components-add-edit.jsx
@@ -382,7 +382,7 @@ export class TeamMembersEdit extends _EditCreate {
                     appropriately withdraw them, or transfer them.</p>
 
                     <p>You <i>can</i> override the delete, but please be advised that this
-                    will <b>retroactively</b> change reports, including GITW/TDO values,
+                    will change reports, including GITW/TDO values,
                     potentially held accountabilities, and more.</p>
 
                     <p>If you wish to continue, please enter the full name '{extraConfirm}' below.</p>

--- a/src/resources/assets/js/submission/team_members/components-add-edit.jsx
+++ b/src/resources/assets/js/submission/team_members/components-add-edit.jsx
@@ -6,10 +6,12 @@ import { delayDispatch, connectRedux, rebind } from '../../reusable/dispatch'
 import { FormTypeahead } from '../../reusable/typeahead'
 
 import { centerQuarterData } from '../core/data'
+import DeleteWarning from '../core/DeleteWarning'
 import { makeAccountabilitiesSelector, makeQuartersSelector } from '../core/selectors'
 import { TEAM_MEMBER_FORM_KEY } from './reducers'
 import { EXIT_CHOICES, EXIT_CHOICES_HELP } from './exit_choice'
 import * as actions from './actions'
+import { teamMemberText as fullName } from './data'
 import { TeamMembersBase, GITW_LABELS, TDO_LABELS } from './components-base'
 
 
@@ -260,7 +262,7 @@ class _EditCreate extends TeamMembersBase {
     saveTeamMember(data) {
         const { centerId, reportingDate } = this.props.params
 
-        this.props.dispatch(actions.stashTeamMember(centerId, reportingDate, data)).then((result) => {
+        return this.props.dispatch(actions.stashTeamMember(centerId, reportingDate, data)).then((result) => {
             if (!result) {
                 return
             }
@@ -286,6 +288,11 @@ class _EditCreate extends TeamMembersBase {
 // Detailed edit of class list
 @connectRedux(teamMembersMapState)
 export class TeamMembersEdit extends _EditCreate {
+    constructor(props) {
+        super(props)
+        rebind(this, 'deleteTeamMember')
+    }
+
     checkLoading() {
         if (!super.checkLoading()) {
             return false
@@ -322,11 +329,13 @@ export class TeamMembersEdit extends _EditCreate {
 
         return (
             <div>
-                <h3>Edit Team Member {teamMember.firstName} {teamMember.lastName}</h3>
+                <h3>Edit Team Member {fullName(teamMember)}</h3>
 
                 <MessagesComponent messages={messages} />
 
                 {super.render()}
+
+                {this.renderDeleteFlow()}
             </div>
         )
     }
@@ -355,6 +364,46 @@ export class TeamMembersEdit extends _EditCreate {
                 </div>
             </div>
         )
+    }
+
+    renderDeleteFlow() {
+        const { currentMember, lookups } = this.props
+        let extraConfirm, spiel
+        if (!currentMember.id) {
+            return
+        } else if (currentMember.meta && currentMember.meta.canDelete) {
+            spiel = <p>Deleting a team member will cause them to be permanently removed.</p>
+        } else if (lookups.user.canOverrideDelete) {
+            extraConfirm = fullName(currentMember)
+            spiel = (
+                <div>
+                    <p><b>Regional Statisticians</b> - This team member cannot be deleted by a statistician.
+                    It is a very rare occasion to delete a team member, note most cases you would want to
+                    appropriately withdraw them, or transfer them.</p>
+
+                    <p>You <i>can</i> override the delete, but please be advised that this
+                    will <b>retroactively</b> change reports, including GITW/TDO values,
+                    potentially held accountabilities, and more.</p>
+
+                    <p>If you wish to continue, please enter the full name '{extraConfirm}' below.</p>
+                </div>
+            )
+        } else {
+            return
+        }
+        return (
+            <div style={{maxWidth: '80em', marginTop: '3em'}}>
+                <DeleteWarning
+                        model={TEAM_MEMBER_FORM_KEY} noun="Team Member" spiel={spiel}
+                        extraConfirm={extraConfirm} onSubmit={this.deleteTeamMember}
+                        buttonState={this.props.teamMembers.saveState} />
+            </div>
+        )
+    }
+
+    deleteTeamMember(data) {
+        data = Object.assign({}, data, {action: 'delete'})
+        return this.saveTeamMember(data)
     }
 }
 

--- a/src/resources/assets/js/submission/team_members/components-index.jsx
+++ b/src/resources/assets/js/submission/team_members/components-index.jsx
@@ -7,7 +7,7 @@ import { delayDispatch, rebind, connectRedux } from '../../reusable/dispatch'
 import { ProgramLeadersIndex } from '../program_leaders/components'
 
 import { TEAM_MEMBERS_COLLECTION_FORM_KEY } from './reducers'
-import { teamMembersData, teamMembersSorts } from './data'
+import { teamMembersData, teamMembersSorts, teamMemberText } from './data'
 import * as actions from './actions'
 import { TeamMembersBase, GITW_LABELS, TDO_LABELS } from './components-base'
 
@@ -216,8 +216,4 @@ class GitwTdoLiveSelect extends BooleanSelectView {
         bits.reverse() // the model looks like path.<teamMemberid>.tdo so if we reverse it, we get the right answer
         this.props.dispatch(actions.weeklyReportingUpdated(bits[1]))
     }
-}
-
-function teamMemberText(teamMember) {
-    return (teamMember.firstName || '(First Name Blank)') + ' ' + (teamMember.lastName || '(Last Name Blank)')
 }

--- a/src/resources/assets/js/submission/team_members/data.js
+++ b/src/resources/assets/js/submission/team_members/data.js
@@ -49,3 +49,7 @@ export const weeklyReportingSave = new LoadingMultiState('team_members/saveWeekl
 export const weeklyReportingData = new InlineBulkWork('team_members/weeklyReporting')
 
 export const messages = new MessageManager('team_members')
+
+export function teamMemberText(teamMember) {
+    return (teamMember.firstName || '(First Name Blank)') + ' ' + (teamMember.lastName || '(Last Name Blank)')
+}

--- a/src/tests/functional/Api/TeamMemberTest.php
+++ b/src/tests/functional/Api/TeamMemberTest.php
@@ -1,11 +1,14 @@
 <?php
 namespace TmlpStats\Tests\Functional\Api;
 
+use App;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use TmlpStats as Models;
+use TmlpStats\Api;
 use TmlpStats\Tests\Functional\FunctionalTestAbstract;
+use TmlpStats\Tests\Mocks\MockContext;
 
 class TeamMemberTest extends FunctionalTestAbstract
 {
@@ -19,6 +22,7 @@ class TeamMemberTest extends FunctionalTestAbstract
     public function setUp()
     {
         parent::setUp();
+        config(['tmlp.earliest_submission' => '2015-01-01']);
 
         $this->center = Models\Center::abbreviation('VAN')->first();
         $this->quarter = Models\Quarter::year(2016)->quarterNumber(1)->first();
@@ -29,9 +33,12 @@ class TeamMemberTest extends FunctionalTestAbstract
             'center_id' => $this->center->id,
             'quarter_id' => $this->quarter->id,
             'reporting_date' => '2016-04-15',
-            'submitted_at' => null,
+            'submitted_at' => '2017-01-01',
             'version' => 'test',
         ]);
+
+        $this->globalReport = Models\GlobalReport::firstOrCreate(['reporting_date' => $this->report->reportingDate]);
+        $this->globalReport->addCenterReport($this->report);
 
         $this->teamMember = factory(Models\TeamMember::class)->create([
             'incoming_quarter_id' => $this->lastQuarter->id,
@@ -45,14 +52,56 @@ class TeamMemberTest extends FunctionalTestAbstract
         $this->headers = ['Accept' => 'application/json'];
     }
 
-    public function testStash()
+    /**
+     * @dataProvider providerStash
+     */
+    public function testStash($data)
     {
-        $this->markTestIncomplete('We need to add tests');
+        $user = $this->createUser('localStatistician', true);
+        $context = MockContext::defaults()->withUser($user)->install();
+        $tmApi = App::make(Api\TeamMember::class);
+
+        $defaults = ['atWeekend' => true, 'gitw' => true, 'tdo' => true, 'teamYear' => 1];
+        $input = array_merge($defaults, $data['input']);
+        $v = $input['incomingQuarter'];
+        $input['incomingQuarter'] = $this->$v->id;
+
+        $result = $tmApi->stash($this->center, $this->report->reportingDate, $input);
+        $this->assertEquals($data['success'], $result['success']);
+        if ($data['success']) {
+            $this->assertTrue($result['storedId'] < 0);
+        }
+        $this->assertEquals($data['numMessages'], count($result['messages']));
+    }
+
+    public function providerStash()
+    {
+        return [
+            [[
+                'input' => ['firstName' => 'person ', 'lastName' => 'One', 'incomingQuarter' => 'lastQuarter'],
+                'success' => true,
+                'numMessages' => 0,
+            ]],
+
+            [[
+                'input' => ['firstName' => 'person', 'lastName' => 'Two', 'incomingQuarter' => 'lastQuarter', 'gitw' => null],
+                'success' => false,
+                'numMessages' => 1,
+            ]],
+        ];
     }
 
     public function testAllForCenter($reportingDate = null)
     {
-        $this->markTestIncomplete('We need to add tests');
+
+        $user = $this->createUser('localStatistician', true);
+        $context = MockContext::defaults()->withUser($user)->install();
+        $tmApi = App::make(Api\TeamMember::class);
+        $results = collect($tmApi->allForCenter($this->center, $this->report->reportingDate, true));
+        $this->assertEquals(1, $results->count());
+        $tm = $results->get($this->teamMember->id);
+        $this->assertEquals($this->teamMember->id, $tm->id);
+        $this->assertFalse(array_get($tm->meta, 'canDelete', false));
     }
 
     /**

--- a/src/tests/functional/FunctionalTestAbstract.php
+++ b/src/tests/functional/FunctionalTestAbstract.php
@@ -14,16 +14,27 @@ class FunctionalTestAbstract extends TestAbstract
 
     protected $faker;
     protected $user;
+    protected $desiredRole = 'administrator'; // For some reason, the default factory is admin
 
     public function setUp()
     {
         parent::setUp();
 
         $this->faker = Factory::create();
-        $this->user = factory(Models\User::class)->create();
-        $this->be($this->user);
+        $this->user = $this->createUser($this->desiredRole, true);
 
         Models\ModelCache::create()->flush();
+    }
+
+    protected function createUser(string $desiredRole, bool $beUser = false): Models\User
+    {
+        $role = Models\Role::firstOrCreate(['name' => $desiredRole]);
+        $user = factory(Models\User::class)->create(['role_id' => $role->id]);
+        if ($beUser) {
+            $this->be($user);
+        }
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
* local statisticians can delete members/apps which they just
  created by mistake, *before* submit.
* regionals can also override the delete and additionally delete team
  items which have already been used in a report.