### PR TITLE
Remove replaced reference when validating program leaders

### DIFF
--- a/src/app/Api/Submission/ProgramLeader.php
+++ b/src/app/Api/Submission/ProgramLeader.php
@@ -72,7 +72,14 @@ class ProgramLeader extends AuthenticatedApiBase
             foreach ($found as $domain) {
                 $domain->meta['localChanges'] = true;
                 $programLeaders[$domain->id] = $domain;
-                $programLeaders['meta'][$domain->accountability] = $domain->id;
+
+                $existingId = array_get($programLeaders['meta'], $domain->accountability);
+                if ($existingId && $existingId != $domain->id) {
+                    $programLeaders['meta'][$domain->accountability] = $domain->id;
+
+                    // If a program leader has been replaced, remove the old reference
+                    unset($programLeaders[$existingId]);
+                }
             }
         }
 


### PR DESCRIPTION
When a program leader is updated, we need to remove the reference from the list before running it through the validator. Otherwise, old PLs will get validated without the statistician being able to fix issues