### PR TITLE
PM/CL attending weekend stats are only stored in actual CSDs

### DIFF
--- a/src/app/Http/Controllers/Encapsulate/GlobalReportTeamSummaryData.php
+++ b/src/app/Http/Controllers/Encapsulate/GlobalReportTeamSummaryData.php
@@ -279,7 +279,7 @@ class GlobalReportTeamSummaryData
                 continue;
             }
 
-            $csd = $report->centerStatsData()->first();
+            $csd = $report->centerStatsData()->actual()->first();
 
             $pm = $report->center->getProgramManager($report->reportingDate);
             $cl = $report->center->getClassroomLeader($report->reportingDate);


### PR DESCRIPTION
This was causing intermittent inaccuracies on the Program Supervisor report.