### PR TITLE
Accountability table cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - 7.0
+  - 7.1
 dist: precise
 
 env:
@@ -11,6 +12,8 @@ env:
 matrix:
   allow_failures:
     - php: 7.0
+      env: PHP_COVERAGE_ON=y
+    - php: 7.1
       env: PHP_COVERAGE_ON=y
 
 sudo: required

--- a/src/app/Accountability.php
+++ b/src/app/Accountability.php
@@ -28,13 +28,6 @@ class Accountability extends Model
         return $query->whereContext($context);
     }
 
-    public function people()
-    {
-        return $this->belongsToMany('TmlpStats\Person', 'accountability_person', 'accountability_id', 'person_id')
-                    ->withPivot(['starts_at', 'ends_at'])
-                    ->withTimestamps();
-    }
-
     /**
      * Remove anyone who is accountable for a given accountability in a given center.
      *

--- a/src/app/AccountabilityMapping.php
+++ b/src/app/AccountabilityMapping.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace TmlpStats;
+
+use Carbon\Carbon;
+use Eloquence\Database\Traits\CamelCaseModel;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class AccountabilityMapping extends Model
+{
+    use CamelCaseModel;
+
+    protected $table = 'accountability_mappings';
+    protected $guarded = ['id'];
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+    ];
+
+    public function scopeByPerson($query, $person): Builder
+    {
+        if ($person instanceof Person) {
+            $person = $person->id;
+        }
+
+        return $query->where('person_id', $person);
+    }
+
+    public function scopeActiveOn($query, Carbon $when): Builder
+    {
+        return $query
+            ->where('starts_at', '<=', $when)
+            ->where('ends_at', '>', $when);
+    }
+
+    public function scopeByAccountability($query, Accountability $accountability): Builder
+    {
+        return $query->where('accountability_id', $accountability->id);
+    }
+
+    public function scopeByCenter($query, $center): Builder
+    {
+        return $query->where('center_id', ($center instanceof Center) ? $center->id : $center);
+    }
+
+    public function accountability(): HasOne
+    {
+        return $this->hasOne(Accountability::class);
+    }
+
+    public function person(): HasOne
+    {
+        return $this->hasOne(Person::class);
+    }
+
+    public static function bulkSetCenterAccountabilities(Center $center, Carbon $startsAt, Carbon $endsAt, array $toApply)
+    {
+        $report = ['created' => 0, 'shortened' => 0, 'deleted' => 0, 'lengthened' => 0];
+        $allExisting = static::byCenter($center)
+            ->where('starts_at', '<', $endsAt) // notice endsAt and startsAt are swapped here
+            ->where('ends_at', '>', $startsAt) // this is on purpose!
+            ->whereIn('accountability_id', array_keys($toApply))
+            ->get()
+            ->groupBy('accountability_id');
+
+        foreach ($toApply as $accId => $people) {
+            $accExisting = collect($allExisting->get($accId))->groupBy('person_id');
+            foreach ($people as $personId) {
+                $existing = $accExisting->pull($personId); // pull is like get, but also removes the item.
+                static::applyCenterPerson($center, $startsAt, $endsAt, $accId, $personId, $existing, $report);
+            }
+
+            // For any remaining people holding this accountability, curtail them (shorten)
+            foreach ($accExisting->flatten(1) as $item) {
+                if ($item->starts_at->lt($startsAt)) {
+                    $item->ends_at = $startsAt;
+                    $item->save();
+                    $report['shortened']++;
+                } else if ($item->ends_at->lte($endsAt)) {
+                    // Fully enclosed within this time range, can delete.
+                    $report['deleted']++;
+                    $item->delete();
+                } else {
+                    $item->starts_at = $item->starts_at->max($endsAt);
+                    $item->save();
+                    $report['shortened']++;
+                }
+            }
+        }
+
+        return $report;
+    }
+
+    /**
+     * This is mostly to move the rather deeply nested logic out for doing the actual apply of some updates to a center-accountability-person
+     * @param  Center $center    The center, naturally.
+     * @param  Carbon $startsAt  Starts At
+     * @param  Carbon $endsAt    Ends At
+     * @param  int    $accId     Accountability ID
+     * @param  int    $personId  Person ID
+     * @param  array|null $existing Anything existing to check.
+     */
+    protected static function applyCenterPerson(Center $center, Carbon $startsAt, Carbon $endsAt, int $accId, int $personId, $existing, &$report)
+    {
+        if ($existing && $existing->count()) {
+            // TODO investigate what it would be like to do a 'gap filling' algorithm here.
+            $threshold = $startsAt->copy()->subDay();
+            $written = false;
+            foreach ($existing as $acc) {
+                if ($written) {
+                    if ($acc->ends_at->gt($endsAt)) {
+                        $acc->starts_at = $endsAt;
+                        $acc->save();
+                    }
+                } else if ($acc->starts_at->lte($startsAt) && $acc->ends_at->gte($threshold)) {
+                    $acc->ends_at = $acc->ends_at->max($endsAt);
+                    $acc->save();
+                    $report['shortened']++;
+                    $written = true;
+                } else if ($acc->ends_at->gt($endsAt)) {
+                    $acc->starts_at = $acc->starts_at->min($startsAt);
+                    $acc->save();
+                    $report['lengthened']++;
+                    $written = true;
+                }
+            }
+            if (!$written) {
+                throw new \Exception("When setting accountability {$accId} for person {$personId} with start {$startsAt} and end {$endsAt}, with existing {$existing}, Nothing written.");
+            }
+        } else {
+            $report['created']++;
+            // simplest scenario, no other entries exist, so add the accountability.
+            static::create([
+                'person_id' => $personId,
+                'accountability_id' => $accId,
+                'center_id' => $center->id,
+                'starts_at' => $startsAt,
+                'ends_at' => $endsAt,
+            ]);
+        }
+
+    }
+
+}

--- a/src/app/AccountabilityMapping.php
+++ b/src/app/AccountabilityMapping.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 use Eloquence\Database\Traits\CamelCaseModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AccountabilityMapping extends Model
 {
@@ -45,14 +45,14 @@ class AccountabilityMapping extends Model
         return $query->where('center_id', ($center instanceof Center) ? $center->id : $center);
     }
 
-    public function accountability(): HasOne
+    public function accountability(): BelongsTo
     {
-        return $this->hasOne(Accountability::class);
+        return $this->belongsTo(Accountability::class);
     }
 
-    public function person(): HasOne
+    public function person(): BelongsTo
     {
-        return $this->hasOne(Person::class);
+        return $this->belongsTo(Person::class);
     }
 
     public static function bulkSetCenterAccountabilities(Center $center, Carbon $startsAt, Carbon $endsAt, array $toApply)

--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -676,34 +676,31 @@ class SubmissionCore extends AuthenticatedApiBase
     public function submitTeamAccountabilities(Models\Center $center, Carbon $reportingDate, Carbon $reportNow, Carbon $quarterEndDate, $teamMembers)
     {
         // Phase 1: make a map of accountability ID -> person
-        $result = [];
+        $toApply = [];
         foreach ($teamMembers as $k => $tm) {
             // no idea why we'd have a negative ID at this point, but let's just be safe.
             if ($tm->id > 0 && count($tm->accountabilities)) {
                 try {
                     $person = $tm->getAssociatedPerson();
+                    foreach ($tm->accountabilities as $accId) {
+                        $toApply[$accId][] = $person->id;
+                    }
                 } catch (\Exception $e) {
                     // TODO send email
-                }
-                foreach ($tm->accountabilities as $accId) {
-                    $result[$accId] = $person;
                 }
             }
         }
         // Phase 2: Loop accountabilities (Skip program managers and classroom leaders for now)
-        $allAccountabilities = Models\Accountability::context('team')->whereNotIn('id', [8, 9])->get();
+        $allAccountabilities = Models\Accountability::context('team')
+            ->whereNotIn('name', ['programManager', 'classroomLeader'])
+            ->get();
         foreach ($allAccountabilities as $accountability) {
-            if (!isset($result[$accountability->id])) {
-                // No one is listed as accountable, remove any existing accountables
-                Models\Accountability::removeAccountabilityFromCenter($accountability->id, $center->id, $reportNow);
-            } else {
-                $person = $result[$accountability->id];
-
-                // If the person doesn't already have this accountability, add it and remove previous holder
-                // Always call takeover to cleanup any stragglers (leftover from spreadsheet migration)
-                $person->takeoverAccountability($accountability, $reportNow, $quarterEndDate);
+            if (!isset($toApply[$accountability->id])) {
+                $toApply[$accountability->id] = [];
             }
         }
+
+        Models\AccountabilityMapping::bulkSetCenterAccountabilities($center, $reportNow, $quarterEndDate, $toApply);
 
     }
 

--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -4,7 +4,9 @@ namespace TmlpStats;
 use Carbon\Carbon;
 use DB;
 use Eloquence\Database\Traits\CamelCaseModel;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use TmlpStats\Traits\CachedRelationships;
 
 class Person extends Model
@@ -92,32 +94,24 @@ class Person extends Model
         return $possibleMembers;
     }
 
+    protected function queryAccountabilityMappings(Carbon $when): Builder
+    {
+        return AccountabilityMapping::byPerson($this)
+            ->activeOn($when);
+    }
+
     /**
      * Get a list of the accountabilities person currently holds
      *
      * @param Carbon $when  Reference date/time for getting accountability.
      * @return array
      */
-    public function getAccountabilities(Carbon $when)
+    public function getAccountabilities(Carbon $when): Collection
     {
-        $allAccountabilities = $this->accountabilities()->get();
-
-        $accountabilities = [];
-        foreach ($allAccountabilities as $myAccountability) {
-            $startsAt = $myAccountability->pivot->starts_at
-                ? Carbon::createFromFormat('Y-m-d H:i:s', $myAccountability->pivot->starts_at)
-                : null;
-
-            $endsAt = $myAccountability->pivot->ends_at
-                ? Carbon::createFromFormat('Y-m-d H:i:s', $myAccountability->pivot->ends_at)
-                : null;
-
-            if ($startsAt && $startsAt->lte($when) && ($endsAt === null || $endsAt->gt($when))) {
-                $accountabilities[] = $myAccountability;
-            }
-        }
-
-        return $accountabilities;
+        return $this->queryAccountabilityMappings($when)
+                    ->with('accountability') // eager-load accountability
+                    ->get() // execute query
+                    ->pluck('accountability'); // get only the 'accountability' sub-object;
     }
 
     /**
@@ -125,17 +119,12 @@ class Person extends Model
      * @param  Carbon $when  Reference date/time for getting accountability.
      * @return array
      */
-    public function getAccountabilityIds(Carbon $when)
+    public function getAccountabilityIds(Carbon $when): array
     {
-        $items = DB::table('accountability_person')
-            ->where('person_id', $this->id)
-            ->where('starts_at', '<=', $when)
-            ->where(function ($query) use ($when) {
-                $query->whereNull('ends_at')
-                      ->orWhere('ends_at', '>', $when);
-            })->pluck('accountability_id');
-
-        return $items;
+        return $this->queryAccountabilityMappings($when)
+                    ->pluck('accountability_id')
+                    ->map(function ($x) {return intval($x);})
+                    ->all();
     }
 
     /**
@@ -145,16 +134,11 @@ class Person extends Model
      * @param  Carbon         $when  Reference date/time for getting accountability.
      * @return boolean
      */
-    public function hasAccountability(Accountability $accountability, Carbon $when)
+    public function hasAccountability(Accountability $accountability, Carbon $when): bool
     {
-        $accountabilities = $this->getAccountabilities($when);
-        foreach ($accountabilities as $myAccountability) {
-            if ($myAccountability->id == $accountability->id) {
-                return true;
-            }
-        }
+        $ap = $this->queryAccountabilityMappings($when)->byAccountability($accountability)->first();
 
-        return false;
+        return ($ap !== null);
     }
 
     /**
@@ -167,7 +151,13 @@ class Person extends Model
     public function addAccountability(Accountability $accountability, Carbon $starts, Carbon $ends)
     {
         if (!$this->hasAccountability($accountability, $starts)) {
-            $this->accountabilities()->attach($accountability->id, ['starts_at' => $starts, 'ends_at' => $ends]);
+            AccountabilityMapping::create([
+                'person_id' => $this->id,
+                'accountability_id' => $accountability->id,
+                'center_id' => $this->centerId,
+                'starts_at' => $starts,
+                'ends_at' => $ends,
+            ]);
         }
     }
 
@@ -209,7 +199,7 @@ class Person extends Model
     /**
      * Get the Region where the person's center is located
      *
-     * @return null|Center
+     * @return null|Region
      */
     public function homeRegion()
     {
@@ -243,34 +233,9 @@ class Person extends Model
         return $query->whereCenterId($center->id);
     }
 
-    public function scopeByAccountability($query, Accountability $accountability, Carbon $when = null)
-    {
-        if ($when == null) {
-            return $query->whereHas('accountabilities', function ($query) use ($accountability) {
-                $query->whereName($accountability->name);
-            });
-        }
-
-        return $query->whereHas('accountabilities', function ($query) use ($accountability, $when) {
-            $query->whereName($accountability->name)
-                  ->where('starts_at', '<=', $when)
-                  ->where(function ($query) use ($when) {
-                      $query->where('ends_at', '>', $when)
-                            ->orWhereNull('ends_at');
-                  });
-        });
-    }
-
     public function scopeIdentifier($query, $identifier)
     {
         return $query->whereIdentifier($identifier);
-    }
-
-    public function accountabilities()
-    {
-        return $this->belongsToMany('TmlpStats\Accountability', 'accountability_person', 'person_id', 'accountability_id')
-                    ->withPivot(['starts_at', 'ends_at'])
-                    ->withTimestamps();
     }
 
     public function center()

--- a/src/database/migrations/2017_09_13_020702_create_accountability_mappings_table.php
+++ b/src/database/migrations/2017_09_13_020702_create_accountability_mappings_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateAccountabilityMappingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //Schema::rename('accountability_person', 'accountability_person_old');
+        Schema::create('accountability_mappings', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('person_id')->unsigned();
+            $table->integer('accountability_id')->unsigned();
+            $table->integer('center_id')->unsigned();
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->timestamps();
+
+            $table->foreign('person_id')->references('id')->on('people');
+            $table->foreign('accountability_id')->references('id')->on('accountabilities');
+            $table->foreign('center_id')->references('id')->on('centers');
+
+            $table->unique(['person_id', 'starts_at', 'accountability_id'], 'idx_ap_person_starts');
+            $table->index(['starts_at']);
+            $table->index(['ends_at']);
+            $table->index(['center_id', 'accountability_id', 'starts_at'], 'idx_ap_center_accountabilities');
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('accountability_mappings');
+    }
+}

--- a/src/database/migrations/2017_09_13_043841_cleanup_accountability_person_table.php
+++ b/src/database/migrations/2017_09_13_043841_cleanup_accountability_person_table.php
@@ -1,0 +1,83 @@
+<?php
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+
+class CleanupAccountabilityPersonTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        ///////////////////////
+        //// PHASE 1: Select accountability_person annotated with center_id
+        $allAps = DB::table('accountability_person')
+            ->leftJoin('people', 'people.id', '=', 'accountability_person.person_id')
+            ->select('people.center_id', 'accountability_person.*')
+            ->orderBy('person_id')->orderBy('accountability_id')->orderBy('starts_at');
+
+        // Group by person and accountability.
+        $byPersonAccountability = [];
+        foreach ($allAps->get() as $oldAp) {
+            $oldAp->starts_at = Carbon::parse($oldAp->starts_at);
+            // Fix: ends_at to a larger value.
+            $oldAp->ends_at = ($oldAp->ends_at != null) ? Carbon::parse($oldAp->ends_at) : Carbon::parse('2019-01-01');
+            $key = "{$oldAp->person_id}:{$oldAp->accountability_id}";
+            $byPersonAccountability[$key][] = $oldAp;
+        }
+
+        $TO_COPY = ['person_id', 'accountability_id', 'center_id', 'starts_at', 'ends_at', 'created_at', 'updated_at'];
+
+        ///////////////////////
+        //// PHASE 2: Take the by person+accountability keyed
+        foreach ($byPersonAccountability as $k => $instances) {
+            $seen = [];
+            foreach ($instances as $oldAp) {
+                $key = "{$oldAp->starts_at}";
+                if (!isset($seen[$key])) {
+                    $seen[$key] = $oldAp;
+                    continue;
+                }
+                $existing = $seen[$key];
+
+                if ($existing->ends_at->lt($oldAp->ends_at)) {
+                    $seen[$key] = $oldAp;
+                }
+            }
+
+            $sValues = array_values($seen);
+            echo "Person $k : From " . count($instances) . ' To ' . count($sValues) . "\n";
+            $toInsert = collect($sValues)
+                ->values()
+                ->map(function ($x) use ($TO_COPY) {
+                    $output = [];
+                    foreach ($TO_COPY as $key) {
+                        $output[$key] = $x->$key;
+                    }
+
+                    return $output;
+                })
+                ->all();
+            DB::table('accountability_mappings')->insert($toInsert);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        /*
+        Schema::table('accountability_person', function (Blueprint $table) {
+            $table->dropForeign(['center_id']);
+            $table->dropIndex(['starts_at']);
+            $table->dropUnique('idx_ap_person_starts');
+            $table->dropIndex('idx_ap_center_accountabilities');
+        });*/
+    }
+}

--- a/src/tests/functional/Models/AccountabilityMappingTest.php
+++ b/src/tests/functional/Models/AccountabilityMappingTest.php
@@ -1,0 +1,186 @@
+<?php
+namespace TmlpStats\Tests\Functional\Models;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use TmlpStats as Models;
+use TmlpStats\Tests\Functional\FunctionalTestAbstract;
+
+class AccountabilityMappingTest extends FunctionalTestAbstract
+{
+    use DatabaseTransactions;
+    use WithoutMiddleware;
+    protected $instantiateApp = true;
+    protected $runMigrations = true;
+    protected $runSeeds = true;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->center = Models\Center::abbreviation('VAN')->first();
+        $this->people = collect([]);
+        $this->allAccountabilities = Models\Accountability::get()->keyBy('name');
+    }
+
+    protected function findAcc($accName)
+    {
+        return $this->allAccountabilities[$accName];
+    }
+
+    public function findPerson($name)
+    {
+        if (!$this->people->has($name)) {
+            $this->people->put($name, factory(Models\Person::class)->create(['first_name' => 'person2', 'center_id' => $this->center->id]));
+        }
+
+        return $this->people->get($name);
+    }
+
+    protected function findPeople($names)
+    {
+        return collect($names)->map([$this, 'findPerson']);
+    }
+
+    /**
+     * @dataProvider providerBulkSetEdgeCases
+     */
+    public function testbulkSetCenterAccountabilities_edgeCases($input)
+    {
+        $known = [];
+        foreach ($input['initial'] as $k => list($person, $acc, $startsAt, $endsAt)) {
+            $model = Models\AccountabilityMapping::create([
+                'person_id' => $this->findPerson($person)->id,
+                'accountability_id' => $this->findAcc($acc)->id,
+                'center_id' => $this->center->id,
+                'starts_at' => Carbon::parse($startsAt),
+                'ends_at' => Carbon::parse($endsAt),
+            ]);
+            $known[$k] = $model->id;
+        }
+        $apply = [];
+        foreach ($input['apply'] as $accName => $pNames) {
+            $apply[$this->findAcc($accName)->id] = $this->findPeople($pNames)->pluck('id')->all();
+        }
+
+        $report = Models\AccountabilityMapping::bulkSetCenterAccountabilities($this->center, $input['startsAt'], $input['endsAt'], $apply);
+
+        foreach ($input['report'] as $k => $v) {
+            $this->assertEquals($v, $report[$k],
+                "Unable to find JSON fragment report[{$k}] = " . print_r($v, true) . ' within [' . print_r($report, true) . '].');
+        }
+
+        if ($callback = array_get($input, 'extraChecks')) {
+            $callback($this, $known);
+        }
+    }
+
+    public function providerBulkSetEdgeCases()
+    {
+        return [
+            [[
+                'initial' => [
+                    'r1' => ['person1', 't1tl', '2016-04-09', '2016-04-22'],
+                ],
+                'startsAt' => Carbon::parse('2016-04-15'),
+                'endsAt' => Carbon::parse('2016-04-29'),
+                'apply' => [
+                    't1tl' => ['person1'],
+                    'gitw' => ['person2'],
+                ],
+                'report' => ['shortened' => 1, 'deleted' => 0, 'created' => 1],
+                'extraChecks' => function ($suite, $known) {
+                    $r1 = Models\AccountabilityMapping::find($known['r1']);
+                    $suite->assertTrue($r1->ends_at->eq(Carbon::parse('2016-04-29')));
+                },
+            ]],
+
+            // Edge case: don't break "future" data.
+            [[
+                'initial' => [
+                    'r1' => ['person1', 't1tl', '2016-04-09', '2016-04-22'],
+                    'r2' => ['person2', 't1tl', '2016-04-22', '2016-05-01'],
+
+                    'future1' => ['person7', 't1tl', '2016-06-01', '2016-09-01'],
+                    'future2' => ['person7', 'gitw', '2016-06-01', '2016-09-01'],
+                ],
+                'startsAt' => Carbon::parse('2016-04-15'),
+                'endsAt' => Carbon::parse('2016-06-01'),
+                'apply' => [
+                    't1tl' => ['person1'],
+                    'gitw' => ['person2'],
+                ],
+                'report' => ['shortened' => 1, 'deleted' => 1, 'created' => 1],
+                'extraChecks' => function ($suite, $known) {
+                    $models = collect($known)->map(function ($x) {return Models\AccountabilityMapping::find($x);});
+                    $r1 = $models->get('r1');
+                    $suite->assertTrue($r1->ends_at->eq(Carbon::parse('2016-06-01')));
+                    $suite->assertNull($models->get('r2'));
+                },
+            ]],
+
+            // Edge case: end overlapping
+            [[
+                'initial' => [
+                    'end1' => ['person1', 't1tl', '2016-05-09', '2016-06-15'],
+                    'end2' => ['person2', 't1tl', '2016-05-09', '2016-06-15'],
+
+                    'future1' => ['person7', 't1tl', '2016-06-21', '2016-09-01'],
+                    'future2' => ['person7', 'gitw', '2016-06-21', '2016-09-01'],
+                ],
+                'startsAt' => Carbon::parse('2016-04-15'),
+                'endsAt' => Carbon::parse('2016-06-01'),
+                'apply' => [
+                    't1tl' => ['person1'],
+                    'gitw' => ['person2'],
+                ],
+                'report' => ['lengthened' => 1, 'shortened' => 1, 'deleted' => 0, 'created' => 1],
+                'extraChecks' => function ($suite, $known) {
+                    $models = collect($known)->map(function ($x) {return Models\AccountabilityMapping::find($x);});
+                    $suite->assertTrue($models->get('end1')->starts_at->eq(Carbon::parse('2016-04-15')));
+                    $suite->assertTrue($models->get('end2')->starts_at->eq(Carbon::parse('2016-06-01')));
+                    $suite->assertNotNull($models->get('future1'));
+                    $suite->assertNotNull($models->get('future2'));
+                },
+            ]],
+
+            // detailed 'past' data
+            [[
+                'initial' => [
+                    'p1' => ['person5', 't1tl', '2016-02-01', '2016-04-14'],
+                    'p2' => ['person6', 'gitw', '2016-02-01', '2016-04-15'],
+                    'p3' => ['person1', 'lf', '2016-02-01', '2016-04-15'],
+                    'p4' => ['person2', 'cap', '2016-02-01', '2016-04-15'],
+
+                    'r1' => ['person1', 't1tl', '2016-04-15', '2016-04-22'],
+                    'r2' => ['person2', 'gitw', '2016-04-15', '2016-04-22'],
+                    'r3' => ['person2', 'lf', '2016-04-15', '2016-04-22'],
+
+                    'future1' => ['person7', 't1tl', '2016-06-01', '2016-09-01'],
+                    'future2' => ['person7', 'gitw', '2016-06-01', '2016-09-01'],
+                ],
+                'startsAt' => Carbon::parse('2016-04-15'),
+                'endsAt' => Carbon::parse('2016-06-01'),
+                'apply' => [
+                    't1tl' => ['person1'],
+                    'cap' => ['person2'],
+                    'gitw' => ['person2'],
+                    'lf' => ['person3'],
+                ],
+                'report' => ['shortened' => 2, 'deleted' => 1, 'created' => 2],
+                'extraChecks' => function ($suite, $known) {
+                    $models = collect($known)->map(function ($x) {return Models\AccountabilityMapping::find($x);});
+                    $suite->assertNotNull($models->get('p1'));
+                    $suite->assertNotNull($models->get('p2'));
+                    $suite->assertNotNull($models->get('p3'));
+                    $suite->assertNotNull($models->get('p4'));
+                    $suite->assertNotNull($models->get('r1'));
+                    $suite->assertNotNull($models->get('r2'));
+                    $suite->assertNull($models->get('r3'));
+                    $suite->assertNotNull($models->get('future1'));
+                },
+            ]],
+        ];
+    }
+}


### PR DESCRIPTION
* Create a new table for accountability->person with:
  - An actual ID primary key to be able to manage duplicates
  - A center_id column to capture the associated center ID
  - Some fixes on older now-invalid SQL defaults.
* Create a migration script to move the data over to new format
* Update using simpler ORM commands instead of raw SQL