### PR TITLE
System Messages Markdown formatting:

### DIFF
--- a/src/resources/assets/js/reusable/markdown.js
+++ b/src/resources/assets/js/reusable/markdown.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { objectAssign } from './ponyfill'
+import { defaultRules, parserFor, reactFor, ruleOutput } from 'simple-markdown'
+
+const paragraphRule = objectAssign({}, defaultRules.paragraph, {
+    react: function(node, output, state) {
+        return React.createElement('p', {}, output(node.content, state))
+    },
+})
+
+const rules = objectAssign({}, defaultRules, {
+    paragraph: paragraphRule
+})
+
+const rawBuiltParser = parserFor(rules)
+export function parse(source) {
+    var blockSource = source + '\n\n'
+    return rawBuiltParser(blockSource, {inline: false})
+}
+export const reactOutput = reactFor(ruleOutput(rules, 'react'))

--- a/src/resources/assets/js/reusable/system-messages/index.jsx
+++ b/src/resources/assets/js/reusable/system-messages/index.jsx
@@ -1,7 +1,7 @@
 import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
-import SimpleMarkdown from 'simple-markdown'
+import { parse, reactOutput } from '../markdown'
 
 import { Alert } from '../ui_basic'
 
@@ -26,14 +26,14 @@ export class SystemMessages extends PureComponent {
             if (message.dismissed) {
                 return
             }
-            const parsed = SimpleMarkdown.defaultBlockParse(message.content)
+            const parsed = parse(message.content)
             const title = (message.updatedAt)? `Updated at ${message.updatedAt}` : undefined
 
             const mDismiss = onDismiss? function() { onDismiss(message.id, ...arguments) } : undefined
+            const renderTitle = (glyph) => <h4 title={title}>{glyph} {message.title || 'System Message'}</h4>
             items.push(
-                <Alert key={message.id} alert={message.level || 'info'} onDismiss={mDismiss}>
-                    &nbsp;<b title={title}>{message.title || 'System Message'}</b>
-                    {SimpleMarkdown.defaultOutput(parsed)}
+                <Alert key={message.id} alert={message.level || 'info'} onDismiss={mDismiss} renderTitle={renderTitle}>
+                    {reactOutput(parsed)}
                 </Alert>
             )
         })

--- a/src/resources/assets/js/reusable/ui_basic.jsx
+++ b/src/resources/assets/js/reusable/ui_basic.jsx
@@ -253,16 +253,20 @@ export class Alert extends React.PureComponent {
         alert: PropTypes.string.isRequired,
         icon: PropTypes.string,
         children: PropTypes.node,
-        onDismiss: PropTypes.func
+        renderTitle: PropTypes.func,
+        onDismiss: PropTypes.func,
     }
 
     static defaultProps = {
         alert: 'info',
-        icon: ''
+        icon: '',
+        renderTitle: function(glyph) {
+            return glyph
+        }
     }
 
     render() {
-        const { alert, icon, children, onDismiss } = this.props
+        const { alert, icon, children, onDismiss, renderTitle } = this.props
         const classes = ['alert' , 'alert-' + alert]
 
         let dismiss
@@ -272,10 +276,12 @@ export class Alert extends React.PureComponent {
         }
 
         const chosenIcon = icon? icon : alertsByKey[alert].icon
+        const glyph = <span className={'glyphicon glyphicon-' + chosenIcon} aria-hidden="true"></span>
+
         return (
             <div className={cssClasses(classes)}>
                 {dismiss}
-                <span className={'glyphicon glyphicon-' + chosenIcon} aria-hidden="true"></span>
+                {renderTitle(glyph)}
                 {children}
             </div>
         )


### PR DESCRIPTION
Use a `<p>` tag instead of a div for paragraphs, so that all of that
meticulous bootstrap CSS continues to work.

Also, clean up the title rendering of the messages.