### PR TITLE
Use mt_rand() instead of time() for generating random stash ids

### DIFF
--- a/src/app/Api/SubmissionData.php
+++ b/src/app/Api/SubmissionData.php
@@ -216,7 +216,7 @@ class SubmissionData extends AuthenticatedApiBase
     // Return a simple ID for generation purposes that is not likely to be used.
     public function generateId()
     {
-        return 0 - time();
+        return 0 - mt_rand(10000000000, 99999999999);
     }
 
     /**


### PR DESCRIPTION
This helps avoid issues when stashing lots of new items using a script (quarter setup).

Turns out when run 1,000,000 times, `mt_rand` also is about 4 times faster than `time()`