### PR TITLE
Fix reports to use the correct center when displaying inactive centers

### DIFF
--- a/src/app/CourseData.php
+++ b/src/app/CourseData.php
@@ -33,6 +33,9 @@ class CourseData extends Model
     {
         switch ($name) {
             case 'center':
+                return $this->statsReport->center;
+            case 'location':
+            case 'startDate':
             case 'type':
                 return $this->course->$name;
             default:

--- a/src/app/Domain/ScoreboardMultiWeek.php
+++ b/src/app/Domain/ScoreboardMultiWeek.php
@@ -38,7 +38,7 @@ class ScoreboardMultiWeek implements Arrayable, \JsonSerializable
 
     public function getWeek(Carbon $day)
     {
-        return $this->weeks[$day->toDateString()];
+        return $this->weeks[$day->toDateString()] ?? null;
     }
 
     public function sortedValues()

--- a/src/app/Http/Controllers/Encapsulate/GlobalReportCoursesData.php
+++ b/src/app/Http/Controllers/Encapsulate/GlobalReportCoursesData.php
@@ -184,11 +184,10 @@ class GlobalReportCoursesData
     {
         $a = new Arrangements\CoursesByCenter(['coursesData' => $coursesData]);
         $coursesByCenter = $a->compose();
-        $coursesByCenter = $coursesByCenter['reportData'];
 
         $statsReports = [];
         $centerReportData = [];
-        foreach ($coursesByCenter as $centerName => $coursesData) {
+        foreach ($coursesByCenter['reportData'] as $centerName => $coursesData) {
             $a = new Arrangements\CoursesWithEffectiveness([
                 'courses' => $coursesData,
                 'reportingDate' => $globalReport->reportingDate,

--- a/src/app/Reports/Arrangements/CoursesByCenter.php
+++ b/src/app/Reports/Arrangements/CoursesByCenter.php
@@ -1,15 +1,14 @@
-<?php namespace TmlpStats\Reports\Arrangements;
+<?php
+namespace TmlpStats\Reports\Arrangements;
 
 class CoursesByCenter extends BaseArrangement
 {
     public function build($data)
     {
-        $coursesData = $data['coursesData'];
-
         $reportData = [];
 
-        foreach ($coursesData as $data) {
-            $reportData[$data->center->name][] = $data;
+        foreach ($data['coursesData'] as $course) {
+            $reportData[$course->center->name][] = $course;
         }
 
         return compact('reportData');

--- a/src/app/Reports/Arrangements/CoursesWithEffectiveness.php
+++ b/src/app/Reports/Arrangements/CoursesWithEffectiveness.php
@@ -48,9 +48,9 @@ class CoursesWithEffectiveness extends BaseArrangement
             $type = $courseData->course->type;
 
             $course = [
-                'centerName' => $courseData->course->center->name,
-                'location'   => $courseData->course->location ?: $courseData->course->center->name,
-                'startDate'  => $courseData->course->startDate,
+                'centerName' => $courseData->center->name,
+                'location'   => $courseData->location ?: $courseData->center->name,
+                'startDate'  => $courseData->startDate,
                 'type'       => $type,
             ];
 

--- a/src/app/Reports/Arrangements/TeamMembersByCenter.php
+++ b/src/app/Reports/Arrangements/TeamMembersByCenter.php
@@ -8,8 +8,8 @@ class TeamMembersByCenter extends BaseArrangement
 
         $reportData = [];
 
-        foreach ($teamMembersData as $data) {
-            $reportData[$data->center->name][] = $data;
+        foreach ($teamMembersData as $member) {
+            $reportData[$member->center->name][] = $member;
         }
 
         return compact('reportData');

--- a/src/app/TeamMemberData.php
+++ b/src/app/TeamMemberData.php
@@ -51,8 +51,9 @@ class TeamMemberData extends Model
             case 'lastName':
             case 'fullName':
             case 'shortName':
-            case 'center':
                 return $this->teamMember->person->$name;
+            case 'center':
+                return $this->statsReport->center;
             case 'teamYear':
             case 'quarterNumber':
             case 'incomingQuarter':

--- a/src/app/TmlpRegistrationData.php
+++ b/src/app/TmlpRegistrationData.php
@@ -48,8 +48,9 @@ class TmlpRegistrationData extends Model
             case 'lastName':
             case 'fullName':
             case 'shortName':
-            case 'center':
                 return $this->registration->person->$name;
+            case 'center':
+                return $this->statsReport->center;
             case 'teamYear':
                 return $this->registration->$name;
             case 'incomingQuarter':

--- a/src/resources/views/reports/courses/next5weeks.blade.php
+++ b/src/resources/views/reports/courses/next5weeks.blade.php
@@ -26,7 +26,7 @@
         <tr>
             <td data-order="{{ $courseData['startDate']->getTimestamp() }}">@date($courseData['startDate'])</td>
             <td class="data-point">
-                @if (isset($statsReports))
+                @if (isset($statsReports[$courseData['centerName']]))
                     @statsReportLink($statsReports[$courseData['centerName']])
                         {{ $courseData['location'] != $courseData['centerName'] ? "{$courseData['centerName']} ({$courseData['location']})" : $courseData['centerName'] }}
                     @endStatsReportLink

--- a/src/resources/views/reports/courses/upcoming.blade.php
+++ b/src/resources/views/reports/courses/upcoming.blade.php
@@ -31,7 +31,7 @@
         <tr>
             <td data-order="{{ $courseData['startDate']->getTimestamp() }}">@date($courseData['startDate'])</td>
             <td class="data-point">
-                @if (isset($statsReports))
+                @if (isset($statsReports[$courseData['centerName']]))
                     @statsReportLink($statsReports[$courseData['centerName']])
                         {{ $courseData['location'] != $courseData['centerName'] ? "{$courseData['centerName']} ({$courseData['location']})" : $courseData['centerName'] }}
                     @endStatsReportLink


### PR DESCRIPTION
When a center is inactive, then marked active, we have to move applications, team members and courses from the old center to the newly active center. This can cause issues when looking at old reports because the center is stored on the underlying person/course object.

Fix by getting the center from the weekly data object's stats report instead.