### PR TITLE
Have UI hide inactive withdraw codes

### DIFF
--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -43,7 +43,7 @@ class SubmissionCore extends AuthenticatedApiBase
         }
 
         // Get values for lookups
-        $withdraw_codes = Models\WithdrawCode::active()->get();
+        $withdraw_codes = Models\WithdrawCode::get();
         $accountabilities = Models\Accountability::orderBy('display')->get();
         $centers = Models\Center::byRegion($center->getGlobalRegion())->active()->orderBy('name')->get();
 

--- a/src/resources/assets/js/submission/applications/AppStatus.jsx
+++ b/src/resources/assets/js/submission/applications/AppStatus.jsx
@@ -108,7 +108,7 @@ export default class AppStatus extends Component {
         if (withdrawn) {
             const { withdraw_codes } = this.props.lookups
             const validCodes = withdraw_codes.filter((code) => {
-                return code.context == 'application' || code.context == 'all'
+                return (code.context == 'application' || code.context == 'all') && code.active
             })
 
             trailer = (

--- a/src/resources/assets/js/submission/team_members/components-add-edit.jsx
+++ b/src/resources/assets/js/submission/team_members/components-add-edit.jsx
@@ -213,7 +213,7 @@ class _EditCreate extends TeamMembersBase {
             break
         case 'wd':
             const validCodes = this.props.lookups.withdraw_codes.filter((code) => {
-                return code.context == 'team_member' || code.context == 'all'
+                return (code.context == 'team_member' || code.context == 'all') && code.active
             })
             content = (
                 <div>


### PR DESCRIPTION
Some apps/team members have already been withdrawn with the now inactive codes. Hide them in the UI so we can continue to display these old withdraws correctly