### PR TITLE
Fix global report to display correct error when there are no local reports for region

### DIFF
--- a/src/app/Api/GlobalReport.php
+++ b/src/app/Api/GlobalReport.php
@@ -98,7 +98,7 @@ class GlobalReport extends AuthenticatedApiBase
 
         $date = $futureDate ?: $report->reportingDate;
 
-        $reportData = $scoreboardData->getWeek($date) ?? [];
+        $reportData = $scoreboardData->ensureWeek($date);
 
         $this->putCache($reportData);
 

--- a/src/app/Api/LocalReport.php
+++ b/src/app/Api/LocalReport.php
@@ -39,7 +39,7 @@ class LocalReport extends AuthenticatedApiBase
 
         $scoreboardData = $this->getQuarterScoreboard($statsReport);
 
-        $response = $scoreboardData->getWeek($statsReport->reportingDate) ?? [];
+        $response = $scoreboardData->ensureWeek($statsReport->reportingDate);
 
         $this->putCache($response);
 

--- a/src/app/Domain/ScoreboardMultiWeek.php
+++ b/src/app/Domain/ScoreboardMultiWeek.php
@@ -38,7 +38,7 @@ class ScoreboardMultiWeek implements Arrayable, \JsonSerializable
 
     public function getWeek(Carbon $day)
     {
-        return $this->weeks[$day->toDateString()] ?? null;
+        return $this->weeks[$day->toDateString()];
     }
 
     public function sortedValues()

--- a/src/app/Domain/ScoreboardMultiWeek.php
+++ b/src/app/Domain/ScoreboardMultiWeek.php
@@ -38,7 +38,7 @@ class ScoreboardMultiWeek implements Arrayable, \JsonSerializable
 
     public function getWeek(Carbon $day)
     {
-        return $this->weeks[$day->toDateString()];
+        return $this->weeks[$day->toDateString()] ?? null;
     }
 
     public function sortedValues()

--- a/src/app/Http/Controllers/GlobalReportController.php
+++ b/src/app/Http/Controllers/GlobalReportController.php
@@ -194,7 +194,7 @@ class GlobalReportController extends Controller
 
             $abbr = $thisRegion->abbreviation;
             foreach (Domain\Scoreboard::GAME_KEYS as $game) {
-                $actual = (int) $regionsData[$abbr]->getWeek($globalReport->reportingDate)->game($game)->actual();
+                $actual = (int) $regionsData[$abbr]->ensureWeek($globalReport->reportingDate)->game($game)->actual();
 
                 $rpp[$abbr][$game] = ($participantCount > 0) ? ($actual / $participantCount) : 0;
                 $rpp[$abbr]['participantCount'] = $participantCount;

--- a/src/app/Http/Controllers/GlobalReportController.php
+++ b/src/app/Http/Controllers/GlobalReportController.php
@@ -101,10 +101,13 @@ class GlobalReportController extends Controller
         ));
     }
 
-    public function showReportChooser(Request $request, Models\Region $region, Carbon $reportingDate)
+    public function showReportChooser(Request $request, Models\Region $region, Carbon $reportingDate, $reason = null)
     {
         $rrd = Encapsulations\RegionReportingDate::ensure($region, $reportingDate);
         $cq = $rrd->getRegionQuarter();
+
+        $this->context->setRegion($region);
+        $this->context->setReportingDate($reportingDate);
 
         // candidates are reporting dates in reverse, but only those which are before this reporting date.
         $dates = collect($cq->listReportingDates())->reverse()->filter(function ($d) use ($reportingDate) {
@@ -128,7 +131,8 @@ class GlobalReportController extends Controller
         return view('reports.report_chooser', compact(
             'reportingDate',
             'maybeReportDate',
-            'maybeReportUrl'
+            'maybeReportUrl',
+            'reason'
         ));
     }
 

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -129,10 +129,13 @@ class StatsReportController extends Controller
         ));
     }
 
-    public function showReportChooser(Request $request, Models\Center $center, Carbon $reportingDate)
+    public function showReportChooser(Request $request, Models\Center $center, Carbon $reportingDate, $reason = null)
     {
         $crd = Encapsulations\CenterReportingDate::ensure($center, $reportingDate);
         $cq = $crd->getCenterQuarter();
+
+        $this->context->setCenter($center);
+        $this->context->setReportingDate($reportingDate);
 
         // candidates are reporting dates in reverse, but only those which are before this reporting date.
         $dates = collect($cq->listReportingDates())->reverse()->filter(function ($d) use ($reportingDate) {
@@ -159,7 +162,8 @@ class StatsReportController extends Controller
         return view('reports.report_chooser', compact(
             'reportingDate',
             'maybeReportDate',
-            'maybeReportUrl'
+            'maybeReportUrl',
+            'reason'
         ));
     }
 

--- a/src/resources/views/reports/report_chooser.blade.php
+++ b/src/resources/views/reports/report_chooser.blade.php
@@ -4,7 +4,7 @@
     <h1>Report Not Found</h1>
 
     <div id="content">
-        We couldn't find a report for <b>{{ $reportingDate->toDateString() }}</b>
+        We couldn't find a report for <b>{{ $reportingDate->toDateString() }}</b>. {{ $reason ?? '' }}
 
         @if ($maybeReportDate && $maybeReportUrl)
             <p>


### PR DESCRIPTION
Update the report chooser feature to display correctly when a regional report exists, but doesn't have any local reports for the displayed region.