### PR TITLE
Distrust the 'Forwarded' header for some android proxies.

### DIFF
--- a/src/config/trustedproxy.php
+++ b/src/config/trustedproxy.php
@@ -57,5 +57,10 @@ return [
         \Illuminate\Http\Request::HEADER_CLIENT_HOST  => 'X_FORWARDED_HOST',
         \Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
         \Illuminate\Http\Request::HEADER_CLIENT_PORT  => 'X_FORWARDED_PORT',
+
+        // As documented in this issue comment:
+        // https://github.com/symfony/symfony/issues/20215#issuecomment-261252378
+        // This is a workaround to ignore the 'Forwarded' header which we don't want.
+        \Illuminate\Http\Request::HEADER_FORWARDED    => null,
     ]
 ];


### PR DESCRIPTION
Needed due to some error emails we are getting from android hosts in India