### PR TITLE
Cleanup some more legacy quarter logic:

### DIFF
--- a/src/app/Api/LiveScoreboard.php
+++ b/src/app/Api/LiveScoreboard.php
@@ -95,7 +95,7 @@ class LiveScoreboard extends AuthenticatedApiBase
         // Step 1: Determine the week for promises to use (may be same week)
         $actualDate = $report->reportingDate;
         if ($actualDate->lt($now)) {
-            $reportingDates = $report->quarter->listReportingDates($report->center);
+            $reportingDates = $report->quarter->getCenterQuarter($report->center)->listReportingDates();
             foreach ($reportingDates as $promiseDate) {
                 if ($promiseDate->gt($now)) {
                     break;

--- a/src/app/Api/Submission/Scoreboard.php
+++ b/src/app/Api/Submission/Scoreboard.php
@@ -22,7 +22,7 @@ class Scoreboard extends AuthenticatedApiBase
         $rq = $submissionCore->reportAndQuarter($center, $reportingDate);
         $quarter = $rq['quarter'];
         $statsReport = $rq['report'];
-        $reportingDates = $quarter->listReportingDates($center);
+        $reportingDates = $quarter->getCenterQuarter($center)->listReportingDates();
 
         if ($statsReport !== null) {
             $weeks = $localReport->getQuarterScoreboard($statsReport);
@@ -124,7 +124,7 @@ class Scoreboard extends AuthenticatedApiBase
         if ($v === null) {
             // Create a blank scoreboard lock with reporting dates filled
             $quarter->setRegion($center->region);
-            $reportingDates = $quarter->listReportingDates($center);
+            $reportingDates = $quarter->getCenterQuarter($center)->listReportingDates();
 
             return new Domain\ScoreboardLockQuarter($reportingDates);
         } else {

--- a/src/app/Domain/CenterQuarter.php
+++ b/src/app/Domain/CenterQuarter.php
@@ -120,13 +120,14 @@ class CenterQuarter implements Arrayable, \JsonSerializable
     }
 
     /**
-     * Get the date when repromises are accepted
+     * Get the date when repromises are accepted.
+     * LEGACY/DEPRECATED: This is only used for the Excel submission.
      *
      * Will check for a setting override, otherwise uses the classroom2 date
      *
      * @return Carbon
      */
-    public function getRepromiseDate()
+    public function getRepromiseDate(): Carbon
     {
         if ($this->repromiseDate === null) {
             $setting = $this->getSetting('repromiseDate');

--- a/src/app/Domain/Logic/QuarterDates.php
+++ b/src/app/Domain/Logic/QuarterDates.php
@@ -54,7 +54,7 @@ class QuarterDates
      *     week1, week2, etc.
      *     An actual date in string format. e.g. 2015-12-31
      * @param  string $settingValue The value we're parsing, usually from a setting.
-     * @param  mixed  $quarterLike  A quarter-like object (CenterQuarter, RegionQuarter) or a Quarter model.
+     * @param  mixed  $quarterLike  A quarter-like object (CenterQuarter, RegionQuarter)
      * @param  Center $center       Needed if $quarterLike is just a plain Quarter.
      * @return Carbon
      */
@@ -96,6 +96,28 @@ class QuarterDates
         }
 
         throw new \Exception("Invalid date format: {$settingValue}");
+    }
+
+    /**
+     * Get the next milestone after the given date 'now'
+     *
+     * @param  mixed       $quarterLike  A quarter-like object (CenterQuarter, RegionQuarter)
+     * @param  Carbon|null $now          The reference date to go off of
+     * @return Carbon                    The next milestone date.
+     */
+    public static function getNextMilestone($quarterLike, Carbon $now = null): Carbon
+    {
+        $now = $now ?: Carbon::now();
+
+        if ($now->gt($quarterLike->classroom3Date)) {
+            return $quarterLike->endWeekendDate;
+        } else if ($now->gt($quarterLike->classroom2Date)) {
+            return $quarterLike->classroom3Date;
+        } else if ($now->gt($quarterLike->classroom1Date)) {
+            return $quarterLike->classroom2Date;
+        } else {
+            return $quarterLike->classroom1Date;
+        }
     }
 }
 

--- a/src/app/Encapsulations/RegionQuarter.php
+++ b/src/app/Encapsulations/RegionQuarter.php
@@ -5,7 +5,6 @@ use App;
 use TmlpStats as Models;
 use TmlpStats\Api;
 use TmlpStats\Domain\Logic\QuarterDates;
-use TmlpStats\Traits\ScopedSettings;
 
 /**
  * RegionQuarter encapsulates data specific to quarters in a region.
@@ -15,7 +14,6 @@ use TmlpStats\Traits\ScopedSettings;
  */
 class RegionQuarter implements \JsonSerializable
 {
-    use ScopedSettings;
     protected $region;
     protected $quarter;
 
@@ -72,6 +70,11 @@ class RegionQuarter implements \JsonSerializable
         }
 
         return $output;
+    }
+
+    public function getNextMilestone(Carbon $ref = null): Carbon
+    {
+        return QuarterDates::getNextMilestone($this, $ref);
     }
 
     public function toArray()

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -149,43 +149,14 @@ class Quarter extends Model
      * @param  Center $center The center for which we want a centerquarter.
      * @return Domain\CenterQuarter
      */
-    public function getCenterQuarter(Center $center)
+    public function getCenterQuarter(Center $center): Domain\CenterQuarter
     {
         return $this->context()->getEncapsulation(Domain\CenterQuarter::class, ['center' => $center, 'quarter' => $this]);
     }
 
-    public function legacyGetRegionQuarter()
+    public function legacyGetRegionQuarter(): Encapsulations\RegionQuarter
     {
         return $this->context()->getEncapsulation(Encapsulations\RegionQuarter::class, ['region' => $this->region, 'quarter' => $this]);
-    }
-
-    public function getNextMilestone(Carbon $now)
-    {
-        if ($now->gt($this->getClassroom3Date())) {
-            $nextMilestone = $this->getQuarterEndDate();
-        } else if ($now->gt($this->getClassroom2Date())) {
-            $nextMilestone = $this->getClassroom3Date();
-        } else if ($now->gt($this->getClassroom1Date())) {
-            $nextMilestone = $this->getClassroom2Date();
-        } else {
-            $nextMilestone = $this->getClassroom1Date();
-        }
-
-        return $nextMilestone;
-    }
-
-    /**
-     * Get the date when repromises are accepted
-     *
-     * Will check for a setting override, otherwise uses the classroom2 date
-     *
-     * @param Center $center
-     *
-     * @return Carbon
-     */
-    public function getRepromiseDate(Center $center)
-    {
-        return $this->getCenterQuarter($center)->getRepromiseDate();
     }
 
     /**
@@ -214,7 +185,7 @@ class Quarter extends Model
      *
      * @param Region $region
      *
-     * @return null|Carbon
+     * @return null|Quarter
      */
     public static function getCurrentQuarter(Region $region)
     {
@@ -333,24 +304,6 @@ class Quarter extends Model
         }
 
         return $quarter;
-    }
-
-    /**
-     * List all reporting dates in a center quarter
-     * @param  Center|null $center The center
-     * @return array               An array of Carbon objects being each reporting week in the quarter
-     */
-    public function listReportingDates(Center $center = null)
-    {
-        $output = [];
-        $d = $this->getFirstWeekDate($center)->copy();
-        $endDate = $this->getQuarterEndDate($center)->copy();
-        while ($d->lte($endDate)) {
-            $output[] = $d;
-            $d = $d->copy()->addWeek();
-        }
-
-        return $output;
     }
 
     /**

--- a/src/app/TeamMember.php
+++ b/src/app/TeamMember.php
@@ -170,11 +170,6 @@ class TeamMember extends Model
         //]);
     }
 
-    public function getIncomingQuarter()
-    {
-        return Quarter::findForCenter($this->incomingQuarterId, $this->person->center);
-    }
-
     public function scopeTeamYear($query, $teamYear)
     {
         return $query->whereTeamYear($teamYear);

--- a/src/tests/unit/Domain/Logic/QuarterDatesTest.php
+++ b/src/tests/unit/Domain/Logic/QuarterDatesTest.php
@@ -1,0 +1,101 @@
+<?php
+namespace TmlpStats\Tests\Unit\Domain\Logic;
+
+use Carbon\Carbon;
+use stdClass;
+use TmlpStats\Domain\Logic\QuarterDates;
+use TmlpStats\Tests\TestAbstract;
+
+class QuarterDatesTest extends TestAbstract
+{
+    /**
+     * @dataProvider providerParseQuarterDate
+     */
+    public function testParseQuarterDate($fakeQuarter, $input, $expectedDate)
+    {
+        $parsed = QuarterDates::parseQuarterDate($input, $fakeQuarter);
+        $this->assertEquals(Carbon::parse($expectedDate), $parsed);
+    }
+
+    public function providerParseQuarterDate()
+    {
+        $q1 = $this->fakeQuarterLike([
+            'startWeekendDate' => '2017-08-18',
+            'classroom1Date' => '2017-08-25',
+            'classroom2Date' => '2017-09-15',
+            'classroom3Date' => '2017-10-27',
+            'endWeekendDate' => '2017-11-17',
+        ]);
+
+        return [
+            [$q1, 'classroom1Date', '2017-08-25'],
+            [$q1, 'classroom2Date', '2017-09-15'],
+            [$q1, 'classroom3Date', '2017-10-27'],
+            [$q1, 'endWeekendDate', '2017-11-17'],
+            [$q1, 'week1', '2017-08-25'],
+            [$q1, 'week12', '2017-11-10'],
+            [$q1, '2017-11-05', '2017-11-05'],
+            [$q1, '2017-11-10', '2017-11-10'],
+        ];
+    }
+
+    /**
+     * @expectedException        Exception
+     * @expectedExceptionMessage No quarter-like object provided
+     */
+    public function testParseQuarterDate__fail_noQuarter()
+    {
+        QuarterDates::parseQuarterDate('classroom2Date', null);
+    }
+
+    /**
+     * @expectedException        Exception
+     * @expectedExceptionMessage Invalid date format: abc-def-ghi
+     */
+    public function testParseQuarterDate__fail_badInput()
+    {
+        QuarterDates::parseQuarterDate('abc-def-ghi', new stdclass());
+    }
+
+    /**
+     * @dataProvider providerGetNextMilestone
+     */
+    public function testGetNextMilestone($fakeQuarter, $refDateInput, $expectedDateInput)
+    {
+
+        $refDate = Carbon::parse($refDateInput);
+        $milestone = QuarterDates::getNextMilestone($fakeQuarter, $refDate);
+        $this->assertEquals(Carbon::parse($expectedDateInput), $milestone);
+    }
+
+    public function providerGetNextMilestone()
+    {
+        $q1 = $this->fakeQuarterLike([
+            'classroom1Date' => '2017-08-25',
+            'classroom2Date' => '2017-09-15',
+            'classroom3Date' => '2017-10-27',
+            'endWeekendDate' => '2017-11-17',
+        ]);
+
+        return [
+            [$q1, '2017-08-01', '2017-08-25'],
+            [$q1, '2017-08-25', '2017-08-25'],
+            [$q1, '2017-08-26', '2017-09-15'],
+            [$q1, '2017-09-15', '2017-09-15'],
+            [$q1, '2017-09-16', '2017-10-27'],
+            [$q1, '2017-10-28', '2017-11-17'],
+            [$q1, '2017-12-05', '2017-11-17'],
+        ];
+    }
+
+    protected function fakeQuarterLike(array $input): stdClass
+    {
+        $fakeQuarter = new stdClass();
+        foreach ($input as $k => $d) {
+            $fakeQuarter->$k = Carbon::parse($d)->startOfDay();
+        }
+
+        return $fakeQuarter;
+    }
+
+}


### PR DESCRIPTION
1. Get rid of Quarter::getNextMilestone and move it to more general
   logic on quarter-like objects
2. RegionQuarter is not a ScopedSettings holder (does not implement
   required method)
3. Get rid of Quarter::listReportingDates and move uses to CQ
4. Remove unused TeamMember::getIncomingQuarter method
5. Remove unused Quarter::getRepromiseDate method
