### PR TITLE
Fix some bugs

### DIFF
--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -28,7 +28,6 @@ class Application extends AuthenticatedApiBase
             foreach ($found as $domain) {
                 $allApplications[$domain->id] = $domain;
                 $domain->meta['localChanges'] = true;
-                $domain->meta['canDelete'] = true;
             }
 
             $deleted = $deleted->map(function ($x) {return intval($x);})->flip();
@@ -42,7 +41,6 @@ class Application extends AuthenticatedApiBase
                     continue;
                 } else if ($domain = array_get($allApplications, $appData->tmlpRegistrationId)) {
                     // it's a small optimization, but prevent creating domain if we have an existing SubmissionData version
-                    $domain->meta['canDelete'] = false;
                     continue;
                 }
 
@@ -88,7 +86,7 @@ class Application extends AuthenticatedApiBase
         $report = LocalReport::ensureStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $teamApp, $appId, $pastWeeks);
 
-        if (!isset($data['_idGenerated']) || $validationResults['valid']) {
+        if (!$teamApp->isNew() || $validationResults['valid']) {
             $submissionData->store($center, $reportingDate, $teamApp);
         } else {
             return [
@@ -101,6 +99,7 @@ class Application extends AuthenticatedApiBase
         return [
             'success' => true,
             'storedId' => $appId,
+            'meta' => $teamApp->meta,
             'valid' => $validationResults['valid'],
             'messages' => $validationResults['messages'],
         ];

--- a/src/app/Api/Application.php
+++ b/src/app/Api/Application.php
@@ -68,6 +68,8 @@ class Application extends AuthenticatedApiBase
             return $this->deleteApp($center, $reportingDate, $data['id']);
         }
 
+        $data['center'] = $center->id;
+
         $submissionData = App::make(SubmissionData::class);
         $appId = $submissionData->numericStorageId($data, 'id');
 

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -83,6 +83,10 @@ class TeamMember extends AuthenticatedApiBase
             return $this->deleteTeamMember($center, $reportingDate, $data['id']);
         }
 
+        if (!isset($data['center'])) {
+            $data['center'] = $center->id;
+        }
+
         $submissionData = App::make(SubmissionData::class);
         $teamMemberId = $submissionData->numericStorageId($data, 'id');
 

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -29,7 +29,6 @@ class TeamMember extends AuthenticatedApiBase
             foreach ($found as $domain) {
                 $allTeamMembers[$domain->id] = $domain;
                 $domain->meta['localChanges'] = true;
-                $domain->meta['canDelete'] = true;
             }
             $deleted = $deleted->map(function ($x) {return intval($x);})->flip();
 
@@ -58,7 +57,6 @@ class TeamMember extends AuthenticatedApiBase
                     $allTeamMembers[$domain->id] = $domain;
                 } else {
                     $domain = $allTeamMembers[$tmd->teamMemberId];
-                    $domain->meta['canDelete'] = false;
                 }
                 $domain->meta['personId'] = $tmd->teamMember->personId;
                 $domain->meta['hasThisWeekReportData'] = ($includeData);
@@ -102,7 +100,7 @@ class TeamMember extends AuthenticatedApiBase
         $report = LocalReport::ensureStatsReport($center, $reportingDate);
         $validationResults = $this->validateObject($report, $domain, $teamMemberId, $pastWeeks);
 
-        if (!isset($data['_idGenerated']) || $validationResults['valid'] || isset($data['_alwaysStash'])) {
+        if (!$domain->isNew() || $validationResults['valid'] || isset($data['_alwaysStash'])) {
             $submissionData->store($center, $reportingDate, $domain);
         } else {
             return [
@@ -115,6 +113,7 @@ class TeamMember extends AuthenticatedApiBase
         return [
             'success' => true,
             'storedId' => $teamMemberId,
+            'meta' => $domain->meta,
             'valid' => $validationResults['valid'],
             'messages' => $validationResults['messages'],
         ];

--- a/src/app/Api/TeamMember.php
+++ b/src/app/Api/TeamMember.php
@@ -83,9 +83,7 @@ class TeamMember extends AuthenticatedApiBase
             return $this->deleteTeamMember($center, $reportingDate, $data['id']);
         }
 
-        if (!isset($data['center'])) {
-            $data['center'] = $center->id;
-        }
+        $data['center'] = $center->id;
 
         $submissionData = App::make(SubmissionData::class);
         $teamMemberId = $submissionData->numericStorageId($data, 'id');

--- a/src/app/Domain/TeamApplication.php
+++ b/src/app/Domain/TeamApplication.php
@@ -185,4 +185,25 @@ class TeamApplication extends ParserDomain
 
         return $output;
     }
+
+    public function __set($key, $value)
+    {
+        parent::__set($key, $value);
+
+        // Automatically populate canDelete meta data
+        if ($key === 'id') {
+            $this->meta['canDelete'] = $this->isNew();
+        }
+    }
+
+    /**
+     * Is this a new Application?
+     *
+     * @return boolean True if object hasn't been persisted
+     */
+    public function isNew()
+    {
+        // Unset or negative ID means this is new
+        return $this->id === null || $this->id < 0;
+    }
 }

--- a/src/app/Domain/TeamMember.php
+++ b/src/app/Domain/TeamMember.php
@@ -273,4 +273,24 @@ class TeamMember extends ParserDomain
         return $person;
     }
 
+    public function __set($key, $value)
+    {
+        parent::__set($key, $value);
+
+        // Automatically populate canDelete meta data
+        if ($key === 'id') {
+            $this->meta['canDelete'] = $this->isNew();
+        }
+    }
+
+    /**
+     * Is this a new Team Member?
+     *
+     * @return boolean True if object hasn't been persisted
+     */
+    public function isNew()
+    {
+        // Unset or negative ID means this is new
+        return $this->id === null || $this->id < 0;
+    }
 }

--- a/src/app/Domain/TeamMember.php
+++ b/src/app/Domain/TeamMember.php
@@ -280,6 +280,8 @@ class TeamMember extends ParserDomain
         // Automatically populate canDelete meta data
         if ($key === 'id') {
             $this->meta['canDelete'] = $this->isNew();
+        } else if ($key === 'quarterNumber') {
+            $this->meta['quarterNumber'] = $value;
         }
     }
 

--- a/src/resources/assets/js/submission/applications/actions.js
+++ b/src/resources/assets/js/submission/applications/actions.js
@@ -71,7 +71,7 @@ export function saveApplication(center, reportingDate, data) {
             if (!result.storedId) {
                 dispatch(messages.replace('create', result.messages))
             } else {
-                let newData = objectAssign({}, data, {id: result.storedId})
+                let newData = objectAssign({}, data, {id: result.storedId, meta: result.meta})
                 dispatch(appsCollection.replaceItem(newData.id, newData))
                 dispatch(messages.replace(result.storedId, result.messages))
 

--- a/src/resources/assets/js/submission/team_members/actions.js
+++ b/src/resources/assets/js/submission/team_members/actions.js
@@ -140,7 +140,7 @@ export function stashTeamMember(center, reportingDate, data) {
                 return
             }
 
-            const newData = objectAssign({}, data, {id: result.storedId, meta: result.meta})
+            const newData = objectAssign({}, data, {id: result.storedId, quarterNumber: result.meta.quarterNumber, meta: result.meta})
             dispatch(messages.replace(newData.id, getMessages(result)))
             dispatch(teamMembersData.replaceItem(newData.id, newData))
 

--- a/src/resources/assets/js/submission/team_members/components-index.jsx
+++ b/src/resources/assets/js/submission/team_members/components-index.jsx
@@ -6,7 +6,7 @@ import { defaultMemoize } from 'reselect'
 import { arrayFind, objectAssign } from '../../reusable/ponyfill'
 
 import { Form, NullableTextControl, BooleanSelectView, SimpleSelect, connectCustomField, AddOneLink } from '../../reusable/form_utils'
-import { ModeSelectButtons, ButtonStateFlip, Alert } from '../../reusable/ui_basic'
+import { ModeSelectButtons, ButtonStateFlip } from '../../reusable/ui_basic'
 import { delayDispatch, rebind, connectRedux } from '../../reusable/dispatch'
 import { createKeyBasedMemoizer } from '../../reusable/selectors'
 import { buildTable } from '../../reusable/tabular'
@@ -260,14 +260,6 @@ export class TeamMembersIndex extends TeamMembersBase {
         return (
             <Form model={TEAM_MEMBERS_COLLECTION_FORM_KEY} onSubmit={this.saveWeeklyReporting}>
                 <h3>Class List</h3>
-                <Alert alert="info">
-                    <b>Dec 2017</b>: This view has changed somewhat.
-                    <p>
-                        In order to get access to the sorts, you now should click on
-                        the column headings. e.g. Clicking the "name" column will sort by that,
-                        and clicking again will reverse sort.
-                    </p>
-                </Alert>
                 <ModeSelectButtons
                         items={TABLES} current={teamMembers.meta.get('format')}
                         onClick={this.changeTableFormat} ariaGroupDesc="Sort Preferences" />


### PR DESCRIPTION
Refactor App/Team Member `canDelete` meta data so it's set properly UI for all objects.
- Fixes issue where it was set incorrectly for stashed data for existing objects on the first week
- Fixes issue where it was not set correctly after adding a new object (before refreshing page)

Make sure `quarterNumber` is set for new team members

Remove old message on Class List