### PR TITLE
Add button to run quarter setup copies

### DIFF
--- a/src/resources/assets/js/admin/flow.jsx
+++ b/src/resources/assets/js/admin/flow.jsx
@@ -16,6 +16,8 @@ export function AdminFlow() {
             <Route path="regions/:regionAbbr" component={regionComponents.SelectQuarter}>
                 <Route path="quarter/:quarterId">
                     <Route path="quarter_dates" component={regionComponents.QuarterDates} />
+                    <Route path="manage_transfers" component={regionComponents.RegionQuarterTransfers} />
+                    <Route path="manage_transfers/from/:centerId" component={regionComponents.RunQuarterTransfer} />
                     <Route path="manage_scoreboards" component={regionComponents.RegionScoreboards} />
                     <Route path="manage_scoreboards/from/:centerId" component={regionComponents.EditScoreboardLock} />
                     <Route path="accountability_rosters" component={regionComponents.AccountabilityRosters} />

--- a/src/resources/assets/js/admin/regions/actions.js
+++ b/src/resources/assets/js/admin/regions/actions.js
@@ -4,7 +4,7 @@ import { normalize } from 'normalizr'
 import { actions as formActions } from 'react-redux-form'
 
 import Api from '../../api'
-import { regionsData, centersData, scoreboardLockData, regionSchema } from './data'
+import { regionsData, centersData, quarterTransferData, scoreboardLockData, regionSchema } from './data'
 
 export function loadRegionsData(region) {
     return regionsData.load({region}, {
@@ -53,6 +53,27 @@ export function saveScoreboardLocks(center, quarter, data, clear) {
                 // Typically, we want to get rid of the data
                 delayDispatch(dispatch, scoreboardLockData.resetAll())
             }
+        })
+    }
+}
+
+export function initializeQuarterTransferData(centerId, quarterId) {
+    return (dispatch) => {
+        const data = objectAssign({}, {centerId, quarterId, applyCenter: [centerId]})
+        dispatch(quarterTransferData.replaceCollection(data))
+        dispatch(quarterTransferData.loadState('loaded'))
+    }
+}
+
+export function runQuarterTransfer(center, quarter) {
+    return (dispatch) => {
+        console.log('>> run transfer', center, quarter)
+        dispatch(quarterTransferData.saveState('loading'))
+        return Api.SubmissionCore.initFirstWeekData({center, quarter}).then((data) => {
+            dispatch(quarterTransferData.saveState('loaded'))
+            data.report.forEach((msg) => {
+                console.log(msg)
+            })
         })
     }
 }

--- a/src/resources/assets/js/admin/regions/center_selector.js
+++ b/src/resources/assets/js/admin/regions/center_selector.js
@@ -1,0 +1,117 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router'
+
+import { rebind } from '../../reusable/dispatch'
+import { Form, formActions } from '../../reusable/form_utils'
+import { FormTypeahead } from '../../reusable/typeahead'
+import { ButtonStateFlip, Alert } from '../../reusable/ui_basic'
+
+export class CenterList extends React.PureComponent {
+    static propTypes = {
+        centers: PropTypes.array.isRequired,
+        linkPrefix: PropTypes.string.isRequired,
+    }
+    render() {
+        const { centers, linkPrefix } = this.props
+
+        const dispCenters = centers.map((center) => {
+            const href = `${linkPrefix}/${center.abbreviation}`
+            return <div key={center.id}><Link to={href}>{center.name}</Link></div>
+        })
+        return (
+            <div>
+                <h4>Please select a center:</h4>
+                {dispCenters}
+            </div>
+        )
+    }
+}
+
+export class CenterUpdateSelector extends React.PureComponent {
+    static propTypes = {
+        buttonLabel: PropTypes.string.isRequired,
+        centerId: PropTypes.string.isRequired,
+        centers: PropTypes.array.isRequired,
+        children: PropTypes.node,
+        data: PropTypes.object.isRequired,
+        dispatch: PropTypes.func.isRequired,
+        model: PropTypes.string.isRequired,
+        onCompleteUrl: PropTypes.string.isRequired,
+        onSubmit: PropTypes.func.isRequired,
+        router: PropTypes.object.isRequired,
+        saveState: PropTypes.object.isRequired,
+    }
+    static defaultProps = {
+        buttonLabel: 'Save',
+    }
+
+    constructor(props) {
+        super(props)
+        rebind(this, 'onSubmit', 'onSelectAll')
+    }
+
+    render() {
+        const { buttonLabel, centerId, centers, children, data, model, saveState } = this.props
+        const otherCenter = data.applyCenter.length != 1 || data.applyCenter[0] != centerId
+
+        let acWarn
+        if (otherCenter) {
+            acWarn = (
+                <div className="col-md-5">
+                <Alert alert="warning" icon="warning-sign">
+                    Applying to a different center or more than one center
+                    copies these locks to those center(s), overwriting
+                    what was there.
+                </Alert>
+                </div>
+            )
+        }
+
+        return (
+            <Form model={model} onSubmit={this.onSubmit}>
+                <div className="row">
+                    {children}
+                    <div className="form-group">
+                        <div className="col-md-2">
+                            <label>Apply to center(s)</label>
+                            <br />
+                            <button type="button" className="btn btn-default" onClick={this.onSelectAll}>Select All Centers</button>
+                        </div>
+                        <div className="col-md-5">
+                            <FormTypeahead
+                                    model={model+'.applyCenter'} items={centers}
+                                    keyProp="abbreviation" labelProp="name"
+                                    multiple={true} rows={8} />
+                        </div>
+                        {acWarn}
+                    </div>
+                </div>
+
+                <ButtonStateFlip buttonClass="btn btn-primary btn-lg"
+                                 loadState={saveState}
+                                 wrapGroup={true}>{buttonLabel}</ButtonStateFlip>
+            </Form>
+        )
+    }
+
+    onSelectAll() {
+        const { centers, dispatch, model } = this.props
+
+        dispatch(formActions.change(`${model}.applyCenter`, centers.map(x => x.abbreviation)))
+    }
+
+    onSubmit(data) {
+        const { dispatch, model, onCompleteUrl, onSubmit, router } = this.props
+
+        dispatch(onSubmit(data.applyCenter[0], data.quarterId, data)).then(() => {
+            const applyCenter = data.applyCenter.slice(1)
+            if (applyCenter.length > 0) {
+                dispatch(formActions.change(`${model}.applyCenter`, applyCenter))
+                setTimeout(() => { this.onSubmit({...data, applyCenter}) }, 200)
+            } else {
+                router.push(onCompleteUrl)
+            }
+        })
+    }
+}

--- a/src/resources/assets/js/admin/regions/components.js
+++ b/src/resources/assets/js/admin/regions/components.js
@@ -1,4 +1,5 @@
 export { SelectQuarter, RegionQuarterIndex } from './selections'
 export { RegionScoreboards, EditScoreboardLock } from './scoreboard_locks'
+export { RegionQuarterTransfers, RunQuarterTransfer } from './quarter_transfer'
 export { QuarterDates } from './quarter_dates'
 export { AccountabilityRosters } from './accountability_rosters'

--- a/src/resources/assets/js/admin/regions/data.js
+++ b/src/resources/assets/js/admin/regions/data.js
@@ -46,6 +46,11 @@ export const scoreboardLockData = new FormReduxLoader({
     extraLMS: ['saveState']
 })
 
+export const quarterTransferData = new FormReduxLoader({
+    prefix: 'admin/quarterTransfer',
+    model: 'admin.regions.quarterTransfer.data',
+    extraLMS: ['saveState']
+})
 
 export const extraData = new SimpleReduxLoader({
     prefix: 'admin/extra',

--- a/src/resources/assets/js/admin/regions/quarter_transfer.jsx
+++ b/src/resources/assets/js/admin/regions/quarter_transfer.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { withRouter } from 'react-router'
+
+import { connectRedux, delayDispatch } from '../../reusable/dispatch'
+import { Alert } from '../../reusable/ui_basic'
+
+import { CenterList, CenterUpdateSelector } from './center_selector'
+import RegionBase from './RegionBase'
+import * as actions from './actions'
+
+const mapStateToProps = (state) => state.admin.regions
+const MODEL = 'admin.regions.quarterTransfer.data'
+
+@connectRedux(mapStateToProps)
+export class RegionQuarterTransfers extends RegionBase {
+    render() {
+        if (!this.checkRegions()) {
+            return <div>Loading...</div>
+        }
+        const baseUri = this.regionQuarterBaseUri()
+        const linkPrefix = `${baseUri}/manage_transfers/from`
+        return (
+            <CenterList centers={this.regionCenters().centers}
+                        linkPrefix={linkPrefix} />
+        )
+    }
+}
+
+@withRouter
+@connectRedux(mapStateToProps)
+export class RunQuarterTransfer extends RegionBase {
+    checkTransfer() {
+        const { centerId, quarterId } = this.props.params
+        const { data, loadState } = this.props.quarterTransfer
+        if ((!data || data.centerId != centerId) && loadState.available) {
+            const { region } = this.regionCenters()
+            if (region) {
+                delayDispatch(this, actions.initializeQuarterTransferData(centerId, quarterId))
+            }
+            return false
+        }
+        return loadState.loaded
+    }
+
+    manageTransfersUrl() {
+        return this.regionQuarterBaseUri() + '/manage_transfers'
+    }
+
+    render() {
+        if (!this.checkRegions() || !this.checkTransfer()) {
+            return <div>Loading...</div>
+        }
+
+        const { dispatch, centers, params: { centerId }, quarterTransfer: { data, saveState }, router } = this.props
+
+        let center
+        const otherCenter = data.applyCenter.length != 1 || data.applyCenter[0] != centerId
+        if (!otherCenter) {
+            center = centers.data[centerId]
+        }
+
+        const onSubmit = (center, quarter) => actions.runQuarterTransfer(center, quarter)
+
+        return (
+            <div>
+                <h2>Transfer Quarter Data - {otherCenter ? 'Multiple Centers' : center.name}</h2>
+                <Alert alert="info">
+                    Transfer team members, applications, and courses from the previous quarter to new quarter.
+                </Alert>
+                <CenterUpdateSelector model={MODEL}
+                                      buttonLabel="Copy"
+                                      centerId={centerId}
+                                      centers={this.regionCenters().centers}
+                                      data={data}
+                                      saveState={saveState}
+                                      onSubmit={onSubmit}
+                                      onCompleteUrl={this.manageTransfersUrl()}
+                                      dispatch={dispatch}
+                                      router={router} />
+                <div style={{paddingTop: '20em'}}>&nbsp;</div>
+            </div>
+        )
+    }
+}

--- a/src/resources/assets/js/admin/regions/reducers.js
+++ b/src/resources/assets/js/admin/regions/reducers.js
@@ -1,12 +1,14 @@
 import { formReducer, modelReducer } from 'react-redux-form'
 import { combineReducers } from 'redux'
-import { regionsData, centersData, scoreboardLockData, extraData } from './data'
+
+import { regionsData, centersData, quarterTransferData, scoreboardLockData, extraData } from './data'
 
 const regionsReducer = combineReducers({
     form: formReducer('admin.regions'),
     regions: regionsData.reducer(),
     centers: centersData.reducer(),
     scoreboardLock: scoreboardLockData.reducer(),
+    quarterTransfer: quarterTransferData.reducer(),
     extra: extraData.reducer(),
     quarterDates: modelReducer('admin.regions.quarterDates'),
 })

--- a/src/resources/assets/js/admin/regions/selections.jsx
+++ b/src/resources/assets/js/admin/regions/selections.jsx
@@ -76,6 +76,7 @@ export class SelectQuarter extends RegionBase {
                 <div>
                     <ul>
                         <li><Link to={base+'/quarter_dates'}>Quarter Dates</Link></li>
+                        <li><Link to={base+'/manage_transfers'}>Transfer Data to New Quarter</Link></li>
                         <li><Link to={base+'/manage_scoreboards'}>Manage Scoreboard Locks</Link></li>
                         <li><Link to={base+'/accountability_rosters'}>Next Qtr Weekend Accountability Rosters</Link></li>
                         <li><a href={'/regions/'+regionId}>Old Admin Page</a></li>


### PR DESCRIPTION
- Break center selector out into it's own component
- Update ScoreboardLocks to use new component
- Add tool to run the quarter transfer
- Update `initFirstWeekData` API handler to reuse existing stashes for new team members