### PR TITLE
Update original migration for help_videos.order to fix sqlite errors

### DIFF
--- a/src/database/migrations/2018_03_08_060236_make_order_to_help_videos_table.php
+++ b/src/database/migrations/2018_03_08_060236_make_order_to_help_videos_table.php
@@ -13,7 +13,7 @@ class MakeOrderToHelpVideosTable extends Migration
     public function up()
     {
         Schema::table('help_videos', function (Blueprint $table) {
-            $table->integer('order')->unsigned()->after('active');
+            $table->integer('order')->unsigned()->nullable()->default(0)->after('active');
         });
     }
 

--- a/src/database/migrations/2018_04_03_060301_make_order_default_null_on_help_video_table.php
+++ b/src/database/migrations/2018_04_03_060301_make_order_default_null_on_help_video_table.php
@@ -12,7 +12,7 @@ class MakeOrderDefaultNullOnHelpVideoTable extends Migration
      */
     public function up()
     {
-        DB::statement("ALTER TABLE `help_videos` MODIFY `order` int(10) unsigned DEFAULT 0;");
+        // DB::statement("ALTER TABLE `help_videos` MODIFY `order` int(10) unsigned DEFAULT 0;");
         // Schema::table('help_videos', function (Blueprint $table) {
         //     $table->integer('order')->unsigned()->nullable()->default(0)->change();
         // });
@@ -25,7 +25,7 @@ class MakeOrderDefaultNullOnHelpVideoTable extends Migration
      */
     public function down()
     {
-        DB::statement("ALTER TABLE `help_videos` MODIFY `order` int(10) unsigned NOT NULL;");
+        // DB::statement("ALTER TABLE `help_videos` MODIFY `order` int(10) unsigned NOT NULL;");
         // Schema::table('help_videos', function (Blueprint $table) {
         //     $table->integer('order')->unsigned()->change();
         // });


### PR DESCRIPTION
Fixes error:
```
SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL (SQL: alter table "help_videos" add column "order" integer not null)
```

SQLite used in tests throw this error. New migration didn't resolve the issue, so we need to run it manually in prod and update the original migration