### PR TITLE
Take 2: Require ProgramLeader travel at the same time as team

### DIFF
--- a/src/app/Api/SubmissionCore.php
+++ b/src/app/Api/SubmissionCore.php
@@ -601,17 +601,23 @@ class SubmissionCore extends AuthenticatedApiBase
     public function calculateProgramLeaderAttending(Models\Center $center, Carbon $reportingDate)
     {
         $leaders = App::make(Api\Submission\ProgramLeader::class)->allForCenter($center, $reportingDate, true);
-        $pmAttending = 0;
-        $clAttending = 0;
+        $pmAttending = null;
+        $clAttending = null;
 
         // This is done due to the limitations of our current storage method.
         // In the future, we should move towards a place we can loop people, allowing situations like multiple classroom leaders (where one's an apprentice or specifically during a weekend of a CL change)
         if (($pmId = $leaders['meta']['programManager']) !== null) {
-            $pmAttending += ($leaders[$pmId]->attendingWeekend) ? 1 : 0;
+            if (!is_null($leaders[$pmId]->attendingWeekend)) {
+                $pmAttending = (int) $pmAttending;
+                $pmAttending += ($leaders[$pmId]->attendingWeekend ? 1 : 0 );
+            }
         }
 
         if (($clId = $leaders['meta']['classroomLeader']) !== null && $clId != $pmId) {
-            $clAttending += ($leaders[$clId]->attendingWeekend) ? 1 : 0;
+            if (!is_null($leaders[$clId]->attendingWeekend)) {
+                $clAttending = (int) $clAttending;
+                $clAttending += ($leaders[$clId]->attendingWeekend ? 1 : 0 );
+            }
         }
 
         return [$pmAttending, $clAttending];

--- a/src/app/Validate/Objects/ApiProgramLeaderValidator.php
+++ b/src/app/Validate/Objects/ApiProgramLeaderValidator.php
@@ -4,9 +4,12 @@ namespace TmlpStats\Validate\Objects;
 use App;
 use Respect\Validation\Validator as v;
 use TmlpStats\Api;
+use TmlpStats\Traits;
 
 class ApiProgramLeaderValidator extends ApiObjectsValidatorAbstract
 {
+    use Traits\ValidatesTravelWithConfig;
+
     protected $accountabilityMap = [
         'programManager' => 'Program Manager',
         'classroomLeader' => 'Classroom Leader',
@@ -21,12 +24,15 @@ class ApiProgramLeaderValidator extends ApiObjectsValidatorAbstract
         $this->dataValidators['phone'] = v::phone();
         $this->dataValidators['email'] = v::email();
         $this->dataValidators['accountability'] = v::in(array_keys($this->accountabilityMap));
-        $this->dataValidators['attendingWeekend'] = v::boolType();
+        $this->dataValidators['attendingWeekend'] = v::optional(v::boolType());
     }
 
     protected function validate($data)
     {
         if (!$this->validateEmail($data)) {
+            $this->isValid = false;
+        }
+        if (!$this->validateTravel($data)) {
             $this->isValid = false;
         }
 
@@ -54,5 +60,28 @@ class ApiProgramLeaderValidator extends ApiObjectsValidatorAbstract
         }
 
         return true;
+    }
+
+    public function validateTravel($data)
+    {
+        // attendingWeekend must be reported starting after the configured date
+        if (!$this->isTimeToCheckTravel()) {
+            return true;
+        }
+
+        $isValid = true;
+        if (is_null($data->attendingWeekend)) {
+            $accountability = $this->accountabilityMap[$data->accountability] ?? $data->accountability;
+            $this->addMessage('error', [
+                'id' => 'PROGRAMLEADER_ATTENDING_WEEKEND_MISSING',
+                'ref' => $data->getReference(['field' => 'attendingWeekend']),
+                'params' => [
+                    'accountability' => $accountability,
+                ],
+            ]);
+            $isValid = false;
+        }
+
+        return $isValid;
     }
 }

--- a/src/resources/lang/en/messages.php
+++ b/src/resources/lang/en/messages.php
@@ -70,6 +70,7 @@ return [
     'GENERAL_INVALID_VALUE' => 'Incorrect value provided for :name (:value).',
     'GENERAL_MISSING_VALUE' => ':name is required, but no value was provided.',
     'PROGRAMLEADER_BOUNCED_EMAIL' => 'The email provided for :accountability (:email) is not reachable. Please correct it.',
+    'PROGRAMLEADER_ATTENDING_WEEKEND_MISSING' => 'Attending weekend must be provided. Please use Y if your :accountability will be at the weekend, or N otherwise.',
     'TEAMAPP_APPIN_DATE_BEFORE_APPOUT_DATE' => 'App in date is before app out date.',
     'TEAMAPP_APPIN_DATE_BEFORE_REG_DATE' => 'App in date is before registration date.',
     'TEAMAPP_APPIN_DATE_CHANGED' => 'Application in date changed from :was to :now.',

--- a/src/tests/unit/Api/SubmissionCoreTest.php
+++ b/src/tests/unit/Api/SubmissionCoreTest.php
@@ -24,8 +24,6 @@ class SubmissionCoreTest extends TestAbstract
         $center = $this->center = new Models\Center(['id' => 123]);
         $center->setRelation('region', new Models\Region(['id' => 123]));
 
-//        $center->region = new Models\Region(['id' => 123, 'abbreviation' => 'na']);
-
         $this->context = MockContext::defaults()->withCenter($this->center)->install();
     }
 
@@ -53,9 +51,17 @@ class SubmissionCoreTest extends TestAbstract
 
         $api = App::make(Api\SubmissionCore::class);
 
-        $result = $api->calculateProgramLeaderAttending($this->center, $this->reportingDate);
-        $this->assertEquals($expected[0], $result[0]);
-        $this->assertEquals($expected[1], $result[1]);
+        list($pm, $cl) = $api->calculateProgramLeaderAttending($this->center, $this->reportingDate);
+        if (is_null($expected[0])) {
+            $this->assertNull($pm);
+        } else {
+            $this->assertEquals($expected[0], $pm);
+        }
+        if (is_null($expected[1])) {
+            $this->assertNull($cl);
+        } else {
+            $this->assertEquals($expected[1], $cl);
+        }
     }
 
     public function providerProgramLeaderAttending()
@@ -85,7 +91,7 @@ class SubmissionCoreTest extends TestAbstract
                     ],
                     1 => ['attendingWeekend' => true],
                 ],
-                [1, 0],
+                [1, null],
 
             ],
 
@@ -110,7 +116,7 @@ class SubmissionCoreTest extends TestAbstract
                         'classroomLeader' => null,
                     ],
                 ],
-                [0, 0],
+                [null, null],
             ],
 
             // Only CL is set
@@ -123,7 +129,7 @@ class SubmissionCoreTest extends TestAbstract
                     1 => ['attendingWeekend' => true],
 
                 ],
-                [0, 1],
+                [null, 1],
             ],
         ];
     }

--- a/src/tests/unit/Validate/Objects/ApiProgramLeaderValidatorTest.php
+++ b/src/tests/unit/Validate/Objects/ApiProgramLeaderValidatorTest.php
@@ -28,6 +28,7 @@ class ApiProgramLeaderValidatorTest extends ApiValidatorTestAbstract
         $this->statsReport->center = null;
 
         $this->setSetting('bouncedEmails', '');
+        $this->setSetting('travelDueByDate', 'classroom2Date');
 
         $this->dataTemplate = [
             'firstName' => 'Keith',
@@ -93,10 +94,6 @@ class ApiProgramLeaderValidatorTest extends ApiValidatorTestAbstract
                     $this->getMessageData($this->messageTemplate, [
                         'id' => 'GENERAL_MISSING_VALUE',
                         'reference.field' => 'accountability',
-                    ]),
-                    $this->getMessageData($this->messageTemplate, [
-                        'id' => 'GENERAL_MISSING_VALUE',
-                        'reference.field' => 'attendingWeekend',
                     ]),
                 ],
                 false,
@@ -206,6 +203,66 @@ class ApiProgramLeaderValidatorTest extends ApiValidatorTestAbstract
                     ]),
                 ],
                 true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerValidateTravel
+     */
+    public function testValidateTravel($data, $expectedMessages, $expectedResult)
+    {
+        $data = $this->getProgramLeader($data);
+
+        $validator = $this->getObjectMock();
+        $result = $validator->run($data);
+
+        $this->assertMessages($expectedMessages, $validator->getMessages());
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerValidateTravel()
+    {
+        return [
+            // validateTravel Passes When Before Second Classroom
+            [
+                [
+                    'attendingWeekend' => null,
+                    '__reportingDate' => Carbon::parse('2016-09-02'),
+                ],
+                [],
+                true,
+            ],
+            // validateTravel Passes When attendingWeekend set
+            [
+                [
+                    'attendingWeekend' => true,
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [],
+                true,
+            ],
+            [
+                [
+                    'attendingWeekend' => false,
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [],
+                true,
+            ],
+            // ValidateTravel Fails When attendingWeekend missing after classroom 2
+            [
+                [
+                    'attendingWeekend' => null,
+                    '__reportingDate' => Carbon::parse('2016-10-07'),
+                ],
+                [
+                    $this->getMessageData($this->messageTemplate, [
+                        'id' => 'PROGRAMLEADER_ATTENDING_WEEKEND_MISSING',
+                        'reference.field' => 'attendingWeekend',
+                    ]),
+                ],
+                false,
             ],
         ];
     }


### PR DESCRIPTION
Reverts tmlpstats/tmlpstats#887

Had to revert this the first time because the not null constraint was still set on the `program_manager_attending_weekend` and `classroom_leader_attending_weekend` fields.